### PR TITLE
Changes for v1.0.2

### DIFF
--- a/kpf/OB_GUI/KPF_OB_GUI.py
+++ b/kpf/OB_GUI/KPF_OB_GUI.py
@@ -722,6 +722,8 @@ class MainWindow(QMainWindow):
                 # Re-run this last to make sure ND filters get greyed out or not properly
                 if 'TakeSimulCal' in contents['SEQ_Observations'][0].keys():
                     self.update_OB('TakeSimulCal', contents['SEQ_Observations'][0]['TakeSimulCal'])
+                if 'AutoExpMeter' in contents['SEQ_Observations'][0].keys():
+                    self.update_OB('AutoExpMeter', contents['SEQ_Observations'][0]['AutoExpMeter'])
                 # save fname as path to use in future
                 self.file_path = Path(fname).parent
                 # Clear other names and star list line

--- a/kpf/OB_GUI/KPF_OB_GUI.py
+++ b/kpf/OB_GUI/KPF_OB_GUI.py
@@ -671,6 +671,7 @@ class MainWindow(QMainWindow):
         elif key == 'Teff':
             self.Teff.setText(f"{value}")
         elif key == 'GuideMode':
+            if value == False: value = 'off'
             self.GuideMode.setCurrentText(value)
             self.GuideCamGain.setEnabled((value not in ['auto', 'off']))
             self.GuideFPS.setEnabled((value not in ['auto', 'off']))
@@ -781,7 +782,7 @@ class MainWindow(QMainWindow):
         result = QFileDialog.getOpenFileName(self, "Open OB File",
                                              f"{self.file_path}",
                                              "OB Files (*yaml);;All Files (*)")
-        self.log.debug('  Got result: {result}')
+        self.log.debug(f'  Got result: {result}')
         if result:
             fname = result[0]
             if fname != '' and Path(fname).exists():
@@ -789,6 +790,7 @@ class MainWindow(QMainWindow):
                 with open(fname, 'r') as f:
                     contents = yaml.safe_load(f)
                 self.log.debug('  Read in YAML')
+                self.log.debug(contents)
                 for key in contents:
                     value = contents[key]
                     self.log.debug(f"  {key}: {value} ({type(value)})")

--- a/kpf/OB_GUI/KPF_OB_GUI.py
+++ b/kpf/OB_GUI/KPF_OB_GUI.py
@@ -452,6 +452,8 @@ class MainWindow(QMainWindow):
                 self.update_OB(key, self.target_names[key])
             self.log.debug(f"other names: {self.target_names['all']}")
             self.other_names.setText(', '.join(self.target_names['all']))
+            self.TargetName.setToolTip(', '.join(self.target_names['all']))
+            self.GaiaID.setToolTip(', '.join(self.target_names['all']))
         self.twomass_params = BuildOBfromQuery.get_Jmag(self.target_names['2MASSID'])
         if self.twomass_params is not None:
             for key in self.twomass_params:

--- a/kpf/OB_GUI/KPF_OB_GUI.py
+++ b/kpf/OB_GUI/KPF_OB_GUI.py
@@ -719,6 +719,9 @@ class MainWindow(QMainWindow):
                             self.update_OB(seq_key, seq_value)
                     else:
                         self.update_OB(key, value)
+                # Re-run this last to make sure ND filters get greyed out or not properly
+                if 'TakeSimulCal' in contents['SEQ_Observations'][0].keys():
+                    self.update_OB('TakeSimulCal', contents['SEQ_Observations'][0]['TakeSimulCal'])
                 # save fname as path to use in future
                 self.file_path = Path(fname).parent
                 # Clear other names and star list line
@@ -781,7 +784,6 @@ class MainWindow(QMainWindow):
         date = utnow-datetime.timedelta(days=1)
         date_str = date.strftime('%Y%b%d').lower()
         tmp_file = Path(f'/s/sdata1701/KPFTranslator_logs/{date_str}/executedOB_{now_str}.yaml').expanduser()
-        print(tmp_file)
         self.write_to_this_file(tmp_file)
 
 #         RunSciOB_cmd = 'echo "Hello World" ; sleep 10'

--- a/kpf/OB_GUI/KPF_OB_GUI.py
+++ b/kpf/OB_GUI/KPF_OB_GUI.py
@@ -672,7 +672,7 @@ class MainWindow(QMainWindow):
             self.Teff.setText(f"{value}")
         elif key == 'GuideMode':
             self.GuideMode.setCurrentText(value)
-            self.GuideCamGain.setEnabled((value != 'auto'))
+            self.GuideCamGain.setEnabled((value not in ['auto', 'off']))
             self.GuideFPS.setEnabled((value != 'auto'))
         elif key == 'GuideCamGain':
             self.GuideCamGain.setCurrentText(value)

--- a/kpf/OB_GUI/KPF_OB_GUI.py
+++ b/kpf/OB_GUI/KPF_OB_GUI.py
@@ -159,9 +159,9 @@ class MainWindow(QMainWindow):
         slewcaltime_kw.stringCallback.connect(self.update_slewcaltime_value)
 
         # request slew cal
-        self.slewcalreq_value = self.findChild(QLabel, 'slewcalreq_value')
-        slewcalreq_kw = kPyQt.kFactory(self.kpfconfig['SLEWCALREQ'])
-        slewcalreq_kw.stringCallback.connect(self.update_slewcalreq_value)
+#         self.slewcalreq_value = self.findChild(QLabel, 'slewcalreq_value')
+#         slewcalreq_kw = kPyQt.kFactory(self.kpfconfig['SLEWCALREQ'])
+#         slewcalreq_kw.stringCallback.connect(self.update_slewcalreq_value)
 
         # slew cal file
         self.slewcalfile_value = self.findChild(QLabel, 'slewcalfile_value')
@@ -405,7 +405,11 @@ class MainWindow(QMainWindow):
     # Slew cal file
     def update_slewcalfile_value(self, value):
         self.log.debug(f'update_slewcalfile_value: {value}')
-        self.slewcalfile_value.setText(f"{Path(value).name}")
+        output_text = f"{Path(value).name}"
+        match_expected = re.match('SlewCal_(.+)\.yaml', output_text)
+        if match_expected is not None:
+            output_text = match_expected.group(1)
+        self.slewcalfile_value.setText(output_text)
 
     ##-------------------------------------------
     ## Methods relating modifying OB fields

--- a/kpf/OB_GUI/KPF_OB_GUI.py
+++ b/kpf/OB_GUI/KPF_OB_GUI.py
@@ -776,7 +776,7 @@ class MainWindow(QMainWindow):
         now_str = utnow.strftime('%Y%m%dat%H%M%S')
         date = utnow-datetime.timedelta(days=1)
         date_str = date.strftime('%Y%b%d').lower()
-        tmp_file = Path(f'~/kpflogs/{date_str}/executedOB_{now_str}.yaml').expanduser()
+        tmp_file = Path(f'/s/sdata1701/KPFTranslator_logs/{date_str}/executedOB_{now_str}.yaml').expanduser()
         print(tmp_file)
         self.write_to_this_file(tmp_file)
 

--- a/kpf/OB_GUI/KPF_OB_GUI.py
+++ b/kpf/OB_GUI/KPF_OB_GUI.py
@@ -673,7 +673,7 @@ class MainWindow(QMainWindow):
         elif key == 'GuideMode':
             self.GuideMode.setCurrentText(value)
             self.GuideCamGain.setEnabled((value not in ['auto', 'off']))
-            self.GuideFPS.setEnabled((value != 'auto'))
+            self.GuideFPS.setEnabled((value not in ['auto', 'off']))
         elif key == 'GuideCamGain':
             self.GuideCamGain.setCurrentText(value)
         elif key == 'GuideFPS':

--- a/kpf/OB_GUI/KPF_OB_GUI.py
+++ b/kpf/OB_GUI/KPF_OB_GUI.py
@@ -240,7 +240,7 @@ class MainWindow(QMainWindow):
 
         # Guider Setup
         self.GuideMode = self.findChild(QComboBox, 'GuideMode')
-        self.GuideMode.addItems(["auto", "manual"])
+        self.GuideMode.addItems(["auto", "manual", "off"])
         self.update_OB('GuideMode', self.OB['GuideMode'])
         self.GuideMode.currentTextChanged.connect(self.set_guide_mode)
         

--- a/kpf/OB_GUI/KPF_OB_GUI.py
+++ b/kpf/OB_GUI/KPF_OB_GUI.py
@@ -382,7 +382,7 @@ class MainWindow(QMainWindow):
     # Slew Cal Timer
     def update_slewcaltime_value(self, value):
         '''Updates value in QLabel and sets color'''
-        self.log.debug(f'update_slewcaltime_value: {value}')
+#         self.log.debug(f'update_slewcaltime_value: {value}')
         value = float(value)
         self.slewcaltime_value.setText(f"{value:.1f} hrs")
         if value < self.good_slew_cal_time:

--- a/kpf/OB_GUI/KPF_OB_GUI.py
+++ b/kpf/OB_GUI/KPF_OB_GUI.py
@@ -451,7 +451,11 @@ class MainWindow(QMainWindow):
         if len(gaiaid.split(' ')) == 2:
             gaiaid = gaiaid.split(' ')[1]
         self.target_names = BuildOBfromQuery.get_names_from_gaiaid(gaiaid)
-        if self.target_names is not None:
+        if self.target_names is None:
+            self.log.error(f'Failed to retrieve target names using {gaiaid}')
+            self.GaiaID.setToolTip(f'Failed to retrieve target names using {gaiaid}')
+            return
+        else:
             for key in ['TargetName', '2MASSID']:
                 self.update_OB(key, self.target_names[key])
             self.log.debug(f"other names: {self.target_names['all']}")

--- a/kpf/OB_GUI/KPF_OB_GUI.ui
+++ b/kpf/OB_GUI/KPF_OB_GUI.ui
@@ -32,7 +32,7 @@
      <rect>
       <x>10</x>
       <y>80</y>
-      <width>301</width>
+      <width>308</width>
       <height>81</height>
      </rect>
     </property>
@@ -43,45 +43,6 @@
      <property name="verticalSpacing">
       <number>6</number>
      </property>
-     <item row="2" column="1">
-      <widget class="QLabel" name="scriptstop_value">
-       <property name="font">
-        <font>
-         <pointsize>11</pointsize>
-        </font>
-       </property>
-       <property name="text">
-        <string>_</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QLabel" name="scriptpause_value">
-       <property name="font">
-        <font>
-         <pointsize>11</pointsize>
-        </font>
-       </property>
-       <property name="text">
-        <string>_</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_4">
-       <property name="font">
-        <font>
-         <pointsize>11</pointsize>
-        </font>
-       </property>
-       <property name="text">
-        <string>Request Script Pause:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
      <item row="0" column="0">
       <widget class="QLabel" name="label">
        <property name="font">
@@ -94,35 +55,6 @@
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="label_5">
-       <property name="font">
-        <font>
-         <pointsize>11</pointsize>
-        </font>
-       </property>
-       <property name="text">
-        <string>Request Script Stop:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="2">
-      <widget class="QPushButton" name="scriptpause_btn">
-       <property name="text">
-        <string>Pause</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="2">
-      <widget class="QPushButton" name="scriptstop_btn">
-       <property name="text">
-        <string>STOP</string>
        </property>
       </widget>
      </item>
@@ -144,6 +76,32 @@
        </property>
        <property name="text">
         <string>scriptname.yaml</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="QLabel" name="scriptstop_value">
+       <property name="font">
+        <font>
+         <pointsize>11</pointsize>
+        </font>
+       </property>
+       <property name="text">
+        <string>_</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0" colspan="2">
+      <widget class="QPushButton" name="scriptstop_btn">
+       <property name="text">
+        <string>Request STOP After Exposure</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0" colspan="2">
+      <widget class="QPushButton" name="fullstop_btn">
+       <property name="text">
+        <string>Immediate STOP Exposure and Script</string>
        </property>
       </widget>
      </item>
@@ -282,7 +240,7 @@
         </font>
        </property>
        <property name="text">
-        <string/>
+        <string>Disabled Detectors:</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -333,6 +291,18 @@
      </item>
      <item row="1" column="1">
       <widget class="QLabel" name="slewcalfile_value">
+       <property name="font">
+        <font>
+         <pointsize>11</pointsize>
+        </font>
+       </property>
+       <property name="text">
+        <string>_</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLabel" name="disabled_detectors_value">
        <property name="font">
         <font>
          <pointsize>11</pointsize>

--- a/kpf/OB_GUI/KPF_OB_GUI.ui
+++ b/kpf/OB_GUI/KPF_OB_GUI.ui
@@ -282,7 +282,7 @@
         </font>
        </property>
        <property name="text">
-        <string>Slew Cal File:</string>
+        <string/>
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -312,7 +312,7 @@
         </font>
        </property>
        <property name="text">
-        <string>Request Slew Cal:</string>
+        <string>Slew Cal:</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -332,18 +332,6 @@
       </widget>
      </item>
      <item row="1" column="1">
-      <widget class="QLabel" name="slewcalreq_value">
-       <property name="font">
-        <font>
-         <pointsize>11</pointsize>
-        </font>
-       </property>
-       <property name="text">
-        <string>_</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
       <widget class="QLabel" name="slewcalfile_value">
        <property name="font">
         <font>

--- a/kpf/__init__.py
+++ b/kpf/__init__.py
@@ -66,6 +66,7 @@ class FailedToReachDestination(FailedPostCondition):
 
 
 LostTipTiltStar = KPFException
+ScriptStopTriggered = KPFException
 
 
 ##-------------------------------------------------------------------------

--- a/kpf/__init__.py
+++ b/kpf/__init__.py
@@ -72,6 +72,9 @@ class FailedToReachDestination(FailedPostCondition):
         super().__init__(msg)
 
 
+LostTipTiltStar = KPFException
+
+
 ##-------------------------------------------------------------------------
 ## Utility functions
 ##-------------------------------------------------------------------------

--- a/kpf/__init__.py
+++ b/kpf/__init__.py
@@ -38,13 +38,6 @@ log = create_KPF_log()
 ##-------------------------------------------------------------------------
 ## Define some exceptions
 ##-------------------------------------------------------------------------
-class KPFQuietException(Exception):
-    def __init__(self, message=""):
-        self.message = message
-        log.warning(self.message)
-        super().__init__(self.message)
-
-
 class KPFException(Exception):
     def __init__(self, message=""):
         self.message = message

--- a/kpf/analysis/AnalyzeGridSearch.py
+++ b/kpf/analysis/AnalyzeGridSearch.py
@@ -231,13 +231,16 @@ def build_FITS_cube(images, comment, ouput_spec_cube, mode='TipTilt',
     fluxcubehdu.header.set('Name', 'Three_Color_Cube')
     fluxcubehdu.header.set('OBJECT', 'Three_Color_Cube')
     wavs = np.array(wavs)
-    wavbin_centers = [475, 525, 575, 625, 675, 725, 775, 825]
-    delta_w = 25
+#     wavbin_centers = [475, 525, 575, 625, 675, 725, 775, 825]
+#     delta_w = 25
+    wavbin_centers = np.arange(470,830,40)
+    delta_w = 20
     color_images = np.zeros((len(wavbin_centers),ny,nx))
     for widx,wav_center in enumerate(wavbin_centers):
         w = np.where((wavs > wav_center-delta_w) & (wavs < wav_center+delta_w))[0]
-        print(f"For {wav_center} nm, found {len(w)} bins")
         color_images[widx,:,:] = np.sum(spec_cube[w,:,:], axis=0)
+        flux = np.sum(color_images[widx,:,:])
+        log.info(f"  For {wav_center} nm, found {len(w)} bins with {flux:.1e} counts")
         fluxcubehdu.header.set(f'Layer{widx+1}', f'{wavbin_centers[widx]}nm')
 
 

--- a/kpf/analysis/AnalyzeGridSearch.py
+++ b/kpf/analysis/AnalyzeGridSearch.py
@@ -233,8 +233,8 @@ def build_FITS_cube(images, comment, ouput_spec_cube, mode='TipTilt',
     wavs = np.array(wavs)
 #     wavbin_centers = [475, 525, 575, 625, 675, 725, 775, 825]
 #     delta_w = 25
-    wavbin_centers = np.arange(470,830,40)
     delta_w = 20
+    wavbin_centers = np.arange(470,830,2*delta_w)
     color_images = np.zeros((len(wavbin_centers),ny,nx))
     for widx,wav_center in enumerate(wavbin_centers):
         w = np.where((wavs > wav_center-delta_w) & (wavs < wav_center+delta_w))[0]
@@ -242,7 +242,6 @@ def build_FITS_cube(images, comment, ouput_spec_cube, mode='TipTilt',
         flux = np.sum(color_images[widx,:,:])
         log.info(f"  For {wav_center} nm, found {len(w)} bins with {flux:.1e} counts")
         fluxcubehdu.header.set(f'Layer{widx+1}', f'{wavbin_centers[widx]}nm')
-
 
     color_cube = np.zeros((2,ny,nx))
     color_cube[0,:,:] = color_images[0,:,:]/color_images[1,:,:]

--- a/kpf/analysis/AnalyzeGridSearch.py
+++ b/kpf/analysis/AnalyzeGridSearch.py
@@ -424,10 +424,13 @@ def build_cube_graphic(hdul, ouput_cube_graphic, mode=mode,
                     model_center = xplot_values[peak_index]
                 else:
                     model_center = yfit
-#             log.info(f"  Using model center = {model_center:.1f}")
             ax1.plot(model_pix+model_center, fit(model_pix)*flux_map_i[peak_index],
                      color=line[0].get_c(), linestyle=':', alpha=0.7,
                      label=f'Model, center={model_center:.1f}')
+            ax1.plot(model_pix+model_center, fit(model_pix+1)*flux_map_i[peak_index],
+                     color=line[0].get_c(), linestyle=':', alpha=0.3)
+            ax1.plot(model_pix+model_center, fit(model_pix-1)*flux_map_i[peak_index],
+                     color=line[0].get_c(), linestyle=':', alpha=0.3)
         ax2.plot(xplot_values, emcount_map_i,
                  marker='o', ds='steps-mid', alpha=1,
                  label=f'SNR {iterated_axis_name}={iterated_pix_value:.1f}')

--- a/kpf/analysis/AnalyzeGridSearch.py
+++ b/kpf/analysis/AnalyzeGridSearch.py
@@ -221,11 +221,25 @@ def build_FITS_cube(images, comment, ouput_spec_cube, mode='TipTilt',
         norm_spec_cube[w,:,:] = spectral_slice / spectral_slice.mean()
 
     flux_map = np.sum(spec_cube, axis=0) / np.sum(spec_cube, axis=0).max()
-    npix = 30
-    color_images = np.zeros((3,ny,nx))
-    color_images[0,:,:] = np.sum(spec_cube[index_450nm-npix:index_450nm+npix,:,:], axis=0)
-    color_images[1,:,:] = np.sum(spec_cube[index_550nm-npix:index_550nm+npix,:,:], axis=0)
-    color_images[2,:,:] = np.sum(spec_cube[index_650nm-npix:index_650nm+npix,:,:], axis=0)
+#     npix = 30
+#     color_images = np.zeros((3,ny,nx))
+#     color_images[0,:,:] = np.sum(spec_cube[index_450nm-npix:index_450nm+npix,:,:], axis=0)
+#     color_images[1,:,:] = np.sum(spec_cube[index_550nm-npix:index_550nm+npix,:,:], axis=0)
+#     color_images[2,:,:] = np.sum(spec_cube[index_650nm-npix:index_650nm+npix,:,:], axis=0)
+
+    fluxcubehdu = fits.ImageHDU()
+    fluxcubehdu.header.set('Name', 'Three_Color_Cube')
+    fluxcubehdu.header.set('OBJECT', 'Three_Color_Cube')
+    wavs = np.array(wavs)
+    wavbin_centers = [475, 525, 575, 625, 675, 725, 775, 825]
+    delta_w = 25
+    color_images = np.zeros((len(wavbin_centers),ny,nx))
+    for widx,wav_center in enumerate(wavbin_centers):
+        w = np.where((wavs > wav_center-delta_w) & (wavs < wav_center+delta_w))[0]
+        print(f"For {wav_center} nm, found {len(w)} bins")
+        color_images[widx,:,:] = np.sum(spec_cube[w,:,:], axis=0)
+        fluxcubehdu.header.set(f'Layer{widx+1}', f'{wavbin_centers[widx]}nm')
+
 
     color_cube = np.zeros((2,ny,nx))
     color_cube[0,:,:] = color_images[0,:,:]/color_images[1,:,:]
@@ -245,12 +259,12 @@ def build_FITS_cube(images, comment, ouput_spec_cube, mode='TipTilt',
     fluxmaphdu.header.set('Name', 'Normalized_Flux_Map')
     fluxmaphdu.header.set('OBJECT', 'Normalized_Flux_Map')
     fluxmaphdu.data = flux_map
-    fluxcubehdu = fits.ImageHDU()
-    fluxcubehdu.header.set('Name', 'Three_Color_Cube')
-    fluxcubehdu.header.set('OBJECT', 'Three_Color_Cube')
-    fluxcubehdu.header.set('Layer1', '450nm')
-    fluxcubehdu.header.set('Layer2', '550nm')
-    fluxcubehdu.header.set('Layer3', '650nm')
+#     fluxcubehdu = fits.ImageHDU()
+#     fluxcubehdu.header.set('Name', 'Three_Color_Cube')
+#     fluxcubehdu.header.set('OBJECT', 'Three_Color_Cube')
+#     fluxcubehdu.header.set('Layer1', '450nm')
+#     fluxcubehdu.header.set('Layer2', '550nm')
+#     fluxcubehdu.header.set('Layer3', '650nm')
     fluxcubehdu.data = color_images
     colormaphdu = fits.ImageHDU()
     colormaphdu.header.set('Name', 'Color_Map_Ratios')

--- a/kpf/analysis/AnalyzeGridSearch.py
+++ b/kpf/analysis/AnalyzeGridSearch.py
@@ -2,7 +2,6 @@
 
 ## Import General Tools
 from pathlib import Path
-import argparse
 import logging
 import re
 
@@ -21,36 +20,7 @@ warnings.filterwarnings('ignore', category=astropy.wcs.FITSFixedWarning, append=
 from matplotlib import pyplot as plt
 from matplotlib.ticker import MultipleLocator, FixedLocator
 
-##-------------------------------------------------------------------------
-## Parse Command Line Arguments
-##-------------------------------------------------------------------------
-## create a parser object for understanding command-line arguments
-p = argparse.ArgumentParser(description='''
-''')
-## add arguments
-p.add_argument('logfile', type=str, nargs='*',
-               help="The logfile or files of the grid search runs to analyze")
-## add flags
-p.add_argument("-v", "--verbose", dest="verbose",
-    default=False, action="store_true",
-    help="Be verbose! (default = False)")
-p.add_argument("--cred2", dest="cred2",
-    default=False, action="store_true",
-    help="Generate CRED2 plots? (default = False)")
-## add options
-p.add_argument("--fiber", dest="fiber", type=str,
-    default='Science',
-    help="The fiber being examined (Science, Sky, or EMSky).")
-p.add_argument("--seeing", dest="seeing", type=float,
-    default=0.7,
-    help="The seeing model to overlay on the fiber coupling plot.")
-p.add_argument("--xfit", dest="xfit", type=float,
-    default=335.5,
-    help="The X pixel position to use as the center when overlaying the model.")
-p.add_argument("--yfit", dest="yfit", type=float,
-    default=258,
-    help="The X pixel position to use as the center when overlaying the model.")
-args = p.parse_args()
+from kpf.KPFTranslatorFunction import KPFTranslatorFunction
 
 
 ##-------------------------------------------------------------------------
@@ -60,10 +30,7 @@ log = logging.getLogger('MyLogger')
 log.setLevel(logging.DEBUG)
 ## Set up console output
 LogConsoleHandler = logging.StreamHandler()
-if args.verbose is True:
-    LogConsoleHandler.setLevel(logging.DEBUG)
-else:
-    LogConsoleHandler.setLevel(logging.INFO)
+LogConsoleHandler.setLevel(logging.INFO)
 LogFormat = logging.Formatter('%(asctime)s %(levelname)8s: %(message)s',
                               datefmt='%Y-%m-%d %H:%M:%S')
 LogConsoleHandler.setFormatter(LogFormat)
@@ -777,7 +744,89 @@ def analyze_grid_search(logfile, fiber='Science', model_seeing=0.7,
     return
 
 
+##-------------------------------------------------------------------------
+## AnalyzeGridSearch
+##-------------------------------------------------------------------------
+class AnalyzeGridSearch(KPFTranslatorFunction):
+    '''
+    ARGS:
+    '''
+    @classmethod
+    def pre_condition(cls, args, logger, cfg):
+        pass
+
+    @classmethod
+    def perform(cls, args, logger, cfg):
+        for logfile in args.get('logfile'):
+            analyze_grid_search(logfile,
+                                fiber=args.get('fiber'),
+                                model_seeing=args.get('seeing'),
+                                xfit=args.get('xfit'), yfit=args.get('yfit'),
+                                generate_cred2=args.get('cred2'),
+                                )
+
+    @classmethod
+    def post_condition(cls, args, logger, cfg):
+        pass
+
+    @classmethod
+    def add_cmdline_args(cls, parser, cfg=None):
+        '''The arguments to add to the command line interface.
+        '''
+        parser.add_argument('logfile', type=str, nargs='*',
+            help="The logfile or files of the grid search runs to analyze")
+        ## add flags
+        parser.add_argument("--cred2", dest="cred2",
+            default=False, action="store_true",
+            help="Generate CRED2 plots? (default = False)")
+        ## add options
+        parser.add_argument("--fiber", dest="fiber", type=str,
+            default='Science',
+            help="The fiber being examined (Science, Sky, or EMSky).")
+        parser.add_argument("--seeing", dest="seeing", type=float,
+            default=0.7,
+            help="The seeing model to overlay on the fiber coupling plot.")
+        parser.add_argument("--xfit", dest="xfit", type=float,
+            default=335.5,
+            help="The X pixel position to use as the center when overlaying the model.")
+        parser.add_argument("--yfit", dest="yfit", type=float,
+            default=258,
+            help="The X pixel position to use as the center when overlaying the model.")
+
+        return super().add_cmdline_args(parser, cfg)
+
+
 if __name__ == '__main__':
+    print('start')
+    ##-------------------------------------------------------------------------
+    ## Parse Command Line Arguments
+    ##-------------------------------------------------------------------------
+    ## create a parser object for understanding command-line arguments
+    import argparse
+    p = argparse.ArgumentParser(description='''
+    ''')
+    ## add arguments
+    p.add_argument('logfile', type=str, nargs='*',
+                   help="The logfile or files of the grid search runs to analyze")
+    ## add flags
+    p.add_argument("--cred2", dest="cred2",
+        default=False, action="store_true",
+        help="Generate CRED2 plots? (default = False)")
+    ## add options
+    p.add_argument("--fiber", dest="fiber", type=str,
+        default='Science',
+        help="The fiber being examined (Science, Sky, or EMSky).")
+    p.add_argument("--seeing", dest="seeing", type=float,
+        default=0.7,
+        help="The seeing model to overlay on the fiber coupling plot.")
+    p.add_argument("--xfit", dest="xfit", type=float,
+        default=335.5,
+        help="The X pixel position to use as the center when overlaying the model.")
+    p.add_argument("--yfit", dest="yfit", type=float,
+        default=258,
+        help="The X pixel position to use as the center when overlaying the model.")
+    args = p.parse_args()
+
     for logfile in args.logfile:
         analyze_grid_search(logfile,
                             fiber=args.fiber,

--- a/kpf/analysis/AnalyzeGuideCube.py
+++ b/kpf/analysis/AnalyzeGuideCube.py
@@ -36,7 +36,7 @@ log.addHandler(LogConsoleHandler)
 ##-------------------------------------------------------------------------
 ## plot_cube_stats
 ##-------------------------------------------------------------------------
-def plot_cube_stats(file, plotfile=None):
+def plot_cube_stats(file, plotfile=None, start=None, end=None):
     t, metadata, _ = read_file(file)
     fps = metadata['FPS']
 
@@ -128,8 +128,8 @@ def plot_cube_stats(file, plotfile=None):
     plt.plot(times[~objectxerr.mask], t['object1_flux'][~objectxerr.mask], 'k-',
              alpha=0.5, drawstyle='steps-mid', label=f'Xpos-Xtarg')
     plt.xlabel('Time (s)')
-    if args.start is not None and args.end is not None:
-        plt.xlim(args.start, args.end)
+    if start is not None and end is not None:
+        plt.xlim(start, end)
     else:
         plt.xlim(0,times[-1])
     plt.ylabel('Flux')
@@ -152,8 +152,8 @@ def plot_cube_stats(file, plotfile=None):
     plt.ylabel('delta pix')
     plt.ylim(plotylim)
     plt.grid()
-    if args.start is not None and args.end is not None:
-        plt.xlim(args.start, args.end)
+    if start is not None and end is not None:
+        plt.xlim(start, end)
     else:
         plt.xlim(0,times[-1])
     plt.xlabel('Time (s)')
@@ -357,7 +357,7 @@ class AnalyzeGuideCube(KPFTranslatorFunction):
 
     @classmethod
     def perform(cls, args, logger, cfg):
-        for file in args.get('file'):
+        for file in args.get('files'):
             file = Path(file).expanduser()
             if file.exists() is False:
                 log.error(f"Could not find file {args.get('file')}")
@@ -371,7 +371,10 @@ class AnalyzeGuideCube(KPFTranslatorFunction):
                         viewer_command = cmd
 
             plotfile = Path(str(file.name).replace('.fits', '.png'))
-            plot_cube_stats(file, plotfile=plotfile)
+            plot_cube_stats(file, plotfile=plotfile,
+                            start=args.get('start', None),
+                            end=args.get('end', None),
+                            )
 
             if viewer_command is not None:
                 log.info(f"Opening {plotfile} using {viewer_command}")

--- a/kpf/analysis/AnalyzeTipTiltPerformance.py
+++ b/kpf/analysis/AnalyzeTipTiltPerformance.py
@@ -221,7 +221,7 @@ def plot_tiptilt_stats(file, plotfile=None, start=None, end=None):
     ax2 = plt.gca().twinx()
     fwhm_line = ax2.plot(times[~maskall], fwhm[~maskall], 'g-',
                          alpha=0.5, drawstyle='steps-mid', label=f'FWHM ({mean_fwhm:.1f} arcsec)')
-    nstars_line = ax2.plot(times, nstars, 'ro',
+    nstars_line = ax2.plot(times, nstars, 'r-',
                          alpha=0.3, markersize=2, label=f'Nstars')
     ax2.set_yticks(np.arange(0,3.2,0.5))
     ax2.set_ylim(0,3.1)

--- a/kpf/analysis/AnalyzeTipTiltPerformance.py
+++ b/kpf/analysis/AnalyzeTipTiltPerformance.py
@@ -82,8 +82,8 @@ def read_file(file):
     if metadata['DATE-END'] is None:
         metadata['DATE-END'] = L0_header_hdu.header.get('DATE-END', None)
 
-    if metadata['IMTYPE'] not in [None, 'Object']:
-        return None, None, None
+#     if metadata['IMTYPE'] not in [None, 'Object']:
+#         return None, None, None
     if guide_origins_hdu is None:
         return None, metadata, guider_cube
     else:

--- a/kpf/analysis/AnalyzeTipTiltPerformance.py
+++ b/kpf/analysis/AnalyzeTipTiltPerformance.py
@@ -217,6 +217,8 @@ def plot_tiptilt_stats(file, plotfile=None, start=None, end=None,
 
     # Mean Flux
     mean_flux = np.nanmean(t['object1_flux'][~maskall])
+    max_flux = np.nanmax(t['object1_flux'][~maskall])
+    min_flux = np.nanmin(t['object1_flux'][~maskall])
     mean_peak = np.nanmean(t['object1_peak'][~maskall])
     max_peak = np.nanmax(t['object1_peak'][~maskall])
     min_peak = np.nanmin(t['object1_peak'][~maskall])
@@ -268,10 +270,10 @@ def plot_tiptilt_stats(file, plotfile=None, start=None, end=None,
         plt.plot([times[instance], times[instance]], [0,flux_plot_max], 'r-', alpha=0.05)
     for instance in w_fewer_detections:
         plt.plot([times[instance], times[instance]], [0,flux_plot_max], 'b-', alpha=0.05)
-#     flux_line = plt.plot(times[~maskall],
-#                          t['object1_flux'][~maskall],
-#                          'g-', alpha=0.5, drawstyle='steps-mid',
-#                          label=f'flux (mean={mean_flux:.1e})')
+    flux_line = plt.plot(times[~maskall],
+                         t['object1_flux'][~maskall],
+                         'g-', alpha=0.5, drawstyle='steps-mid',
+                         label=f'flux (max={max_flux/1000:.1f}k, mean={mean_flux/1000:.1f}k)')
     if start is not None and end is not None:
         plt.xlim(start, end)
     else:
@@ -286,10 +288,11 @@ def plot_tiptilt_stats(file, plotfile=None, start=None, end=None,
                              t['object1_peak'][~maskall],
                              'k-', alpha=0.3, drawstyle='steps-mid',
                              label=f'peak (max={max_peak/1000:.1f}k, mean={mean_peak/1000:.1f}k)')
-#     plt.ylabel('Peak (ADU)')
-    plt.ylim(0,2**14)
-#     plt.legend(handles=[flux_line[0], peak_line[0]], loc='lower center')
-    plt.legend(handles=[peak_line[0]], loc='lower center')
+    ax_peak.set_ylabel('Peak (ADU)')
+#     ax_peak.set_ylim(0,2**14)
+    ax_peak.set_ylim(0,min([2**14, 1.5*max_peak]))
+    plt.legend(handles=[flux_line[0], peak_line[0]], loc='lower center')
+#     plt.legend(handles=[peak_line[0]], loc='lower center')
 
     # FWHM Plot
     plt.subplot(3,2,2)

--- a/kpf/analysis/BuildTipTiltGIF.py
+++ b/kpf/analysis/BuildTipTiltGIF.py
@@ -1,0 +1,151 @@
+import argparse
+import sys
+import os
+import yaml
+from pathlib import Path
+import logging
+import subprocess
+from datetime import datetime, timedelta
+
+import numpy as np
+from astropy.io import fits
+from astropy import nddata
+from astropy.table import Table, Column
+from astropy import visualization as vis
+
+from matplotlib import animation
+from matplotlib import pyplot as plt
+
+
+##-------------------------------------------------------------------------
+## Parse Command Line Arguments
+##-------------------------------------------------------------------------
+## create a parser object for understanding command-line arguments
+p = argparse.ArgumentParser(description='''
+''')
+## add arguments
+p.add_argument('file', type=str,
+               help="Input FITS file with guider cube")
+args = p.parse_args()
+
+
+##-------------------------------------------------------------------------
+## read_file
+##-------------------------------------------------------------------------
+def read_file(file):
+    '''Read the file on disk, either the L0 file or the kpfguide_cube file.
+    
+    Return an astropy.table.Table of telemetry, the image cube (if present),
+    and a dictionary with selected metadata.
+    '''
+    hdul = fits.open(file)
+    # print(hdul.info())
+    guider_cube = None
+    guide_origins_hdu = None
+    guide_cube_header_hdu = fits.PrimaryHDU()
+    L0_header_hdu = fits.PrimaryHDU()
+    for hdu in hdul:
+        if hdu.name == 'guider_cube_origins':
+            print(f"Found: {hdu.name}")
+            guide_origins_hdu = hdu
+        if hdu.name == 'guider_avg':
+            print(f"Found: {hdu.name}")
+            guide_cube_header_hdu = hdu
+        if hdu.name == 'PRIMARY':
+            print(f"Found: {hdu.name}")
+            L0_header_hdu = hdu
+        if hdu.name == 'guider_cube':
+            print(f"Found: {hdu.name}")
+            guider_cube = nddata.CCDData(hdu.data, unit='adu')
+    # Assemble metadata
+    metadata = {'FPS': guide_cube_header_hdu.header.get('FPS', None),
+                'DATE-BEG': guide_cube_header_hdu.header.get('DATE-BEG', None),
+                'DATE-END': guide_cube_header_hdu.header.get('DATE-END', None),
+                'IMTYPE': L0_header_hdu.header.get('IMTYPE', None),
+                'Gmag': L0_header_hdu.header.get('GAIAMAG', None),
+                'Jmag': L0_header_hdu.header.get('2MASSMAG', None),
+                'TARGNAME': L0_header_hdu.header.get('FULLTARG', None),
+                'IMTYPE': L0_header_hdu.header.get('IMTYPE', None),
+                'GAIN': guide_cube_header_hdu.header.get('Gain', None)
+               }
+    if metadata['FPS'] is None:
+        # Assume 100 FPS
+        metadata['FPS'] = 100
+    if metadata['DATE-BEG'] is None:
+        metadata['DATE-BEG'] = L0_header_hdu.header.get('DATE-BEG', None)
+    if metadata['DATE-END'] is None:
+        metadata['DATE-END'] = L0_header_hdu.header.get('DATE-END', None)
+
+#     if metadata['IMTYPE'] not in [None, 'Object']:
+#         return None, None, None
+    if guide_origins_hdu is None:
+        return None, metadata, guider_cube
+    else:
+        return Table(guide_origins_hdu.data), metadata, guider_cube
+
+
+
+##-------------------------------------------------------------------------
+## generate_cube_gif
+##-------------------------------------------------------------------------
+def generate_cube_gif(file, giffile):
+    print('Generating animation')
+    t, metadata, cube = read_file(file)
+    if t is None: return
+
+    start = datetime.fromisoformat(metadata['DATE-BEG'])
+    end = datetime.fromisoformat(metadata['DATE-END'])
+    duration = (end - start).total_seconds()
+    fps = metadata['FPS']
+    nf, ny, nx = cube.shape
+    norm = vis.ImageNormalize(cube,
+                          interval=vis.AsymmetricPercentileInterval(1.5,99.99),
+                          stretch=vis.LogStretch())
+
+    fig = plt.figure(figsize=(8,8))
+    fps = 10
+    if sys.platform == 'darwin':
+#         writer = animation.ImageMagickWriter(fps=fps)
+#         writer = animation.ImageMagickFileWriter(fps=fps)
+        writer = animation.FFMpegWriter(fps=fps)
+#         writer = animation.PillowWriter(fps=fps)
+    else:
+#         writer = animation.ImageMagickWriter(fps=fps)
+#         writer = animation.ImageMagickFileWriter(fps=fps)
+#         writer = animation.FFMpegWriter(fps=fps)
+        writer = animation.PillowWriter(fps=fps)
+
+    # ims is a list of lists, each row is a list of artists to draw in the
+    # current frame; here we are just animating one artist, the image, in
+    # each frame
+    print('Building individual frames')
+    ims = []
+    for j,im in enumerate(cube):
+        plt.title(f"{file.name}: {duration:.1f} s, {nf:d} frames")
+        im = plt.imshow(im, origin='lower', cmap='gray', norm=norm, animated=True)
+        frametext = plt.text(nx-20, ny-5, f"{j:04d}/{nf:04d}", color='r')
+        xtpix = nx/2
+        ytpix = ny/2
+        tlines = plt.plot(xtpix, ytpix, 'bx')
+        lines = []
+        if t[j]['object1_x'] > 0 and t[j]['object1_y'] > 0:
+            xpix = t[j]['object1_x'] - (t[j]['target_x'] - nx/2)
+            ypix = t[j]['object1_y'] - (t[j]['target_y'] - ny/2)
+            lines = plt.plot(xpix, ypix, 'r+')
+        newim = [im] + [frametext] + lines + tlines
+        ims.append(newim)
+
+    print('Building animation')
+    ani = animation.ArtistAnimation(fig, ims, interval=1000/fps, blit=True,
+                                    repeat_delay=1000)
+    print(f'Writing {giffile} using {writer}')
+    p = Path(giffile)
+    if p.expanduser().exists(): p.unlink()
+    ani.save(f"{giffile}", writer)
+    print('Done')
+
+
+if __name__ == '__main__':
+    file = Path(args.file)
+    giffile = file.name.replace('.fits', '.gif')
+    generate_cube_gif(file, giffile)

--- a/kpf/analysis/Fit2DGridSearch.py
+++ b/kpf/analysis/Fit2DGridSearch.py
@@ -1,0 +1,228 @@
+from pathlib import Path
+import re
+from datetime import datetime, timedelta
+
+import numpy as np
+from astropy.io import fits
+from astropy.table import Table, Column
+from astropy.modeling import models, fitting
+from astropy.time import Time
+from astroquery.vizier import Vizier
+from astropy import units as u
+from astropy.coordinates import SkyCoord, EarthLocation, AltAz
+
+import matplotlib as mpl
+from matplotlib import pyplot as plt
+
+from kpf.KPFTranslatorFunction import KPFTranslatorFunction
+
+
+def fit_fiber_centering_parameters_one_color(hdul, color=None, xcent=335.5, ycent=258.0, plot=True, nplots=4):
+    nlayers, ny, nx = hdul[5].data.shape
+
+    if nx > ny:
+        cent = xcent
+    else:
+        cent = ycent
+    if color == 0:
+        if nx > ny:
+            flux_map = hdul[5].data[4][0,:]
+        else:
+            flux_map = hdul[5].data[4][:,0]
+        color_string = 'all'
+    else:
+        if nx > ny:
+            flux_map = hdul[3].data[color-1][0,:]
+        else:
+            flux_map = hdul[3].data[color-1][:,0]
+        color_string = hdul[3].header.get(f"Layer{color}")
+    # color_maps = hdul[3].data
+    # color_maps_colors = [hdul[3].header.get(f"Layer{i}") for i in [1,2,3]]
+
+    pixel_values = hdul[5].data[0][0,:] if nx > ny else hdul[5].data[1][:,0]
+    pixel_strings = [f"{val:.1f}" for val in pixel_values]
+
+    # Build Coupling Model
+    # Uses data from Steve Gibson
+    resulting_fits = {'0.50': None, '0.70': None, '0.90': None}
+    for seeing in resulting_fits.keys():
+        
+        model_file = Path(__file__).parent / Path(f'Fiber Coupling Model seeing {seeing} arcsec.csv')
+        t = Table.read(f"{model_file}", format='ascii.csv')
+        pix_scale = 0.058
+        model_pix = np.array(t['Fiber_offset_arcsec'])/pix_scale
+        model_flux = np.array(t['Percent_thru'])/max(t['Percent_thru'])
+        fit0 = models.Polynomial1D(degree=4)
+        fitter = fitting.LinearLSQFitter()
+        fit = fitter(fit0, model_pix, model_flux)
+        resulting_fits[seeing] = (fit, model_pix, model_flux)
+
+    delta_cents = np.linspace(-3,3,61)
+    flux_ratios = np.linspace(0.9,1.1,21)
+    chisq = np.zeros((3,len(delta_cents),len(flux_ratios)))
+    for i,seeing in enumerate(resulting_fits.keys()):
+        fit = resulting_fits[seeing][0]
+        model_pix = resulting_fits[seeing][1]
+        for k,flux_ratio in enumerate(flux_ratios):
+            for j,delta_cent in enumerate(delta_cents):
+                pixel_offsets = pixel_values - cent - delta_cent
+                w = np.where((pixel_offsets > min(model_pix)) & (pixel_offsets < max(model_pix)))
+                model = fit(pixel_offsets[w])*max(flux_map)*flux_ratio
+                diff = flux_map[w] - model
+                chisq[i,j,k] = np.sum(diff**2/model)
+
+    best_i, best_j, best_k = np.unravel_index(chisq.argmin(), chisq.shape)
+    best_seeing = list(resulting_fits.keys())[best_i]
+    best_flux_ratio = flux_ratios[best_k]
+    best_delta_cent = delta_cents[best_j]
+    # print(f"Seeing = {best_seeing}")
+    # print(f"Flux Adjustment = {best_flux_ratio:.2f}")
+    # print(f"  {color_string} Center Position = {cent:.2f} {best_delta_cent:+.2f} = {cent+best_delta_cent:.2f} pix")
+
+    if plot is True:
+        plt.subplot(nplots,1,1+color)
+        title = f"ChiSq vs. Center Position Adjustment ({color_string})"
+        plt.title(title)
+        for i,seeing in enumerate(resulting_fits.keys()):
+            line = plt.plot(delta_cents, chisq[i,:,best_k], marker='x', label=f"Seeing={seeing}",
+                            alpha=1 if i==best_i else 0.2)
+            plt.plot(delta_cents, np.ones(len(delta_cents))*min(chisq[i,:,best_k]),
+                     linestyle=':', color=line[0].get_c(),
+                     alpha=1 if i==best_i else 0.2)
+            plt.plot([best_delta_cent,best_delta_cent], [chisq.min(), chisq.max()], 'r-')
+        plt.legend(loc='best')
+        plt.yscale("log")
+        plt.ylabel('Chi Squared')
+        if color == nplots-1:
+            plt.xlabel('Center Position Offset (pix)')
+
+    return best_delta_cent, cent + best_delta_cent, float(best_seeing)
+
+def fit_fiber_centering_parameters(fgs_cube_file, xcent=335.5, ycent=258.0, plot=False, targname=None):
+    hdul = fits.open(fgs_cube_file)
+    dcs = []
+    cs = []
+    wavs = []
+    seeing = []
+    if plot is True:
+        plt.figure(figsize=(12,16))
+    ncolors = hdul[3].data.shape[0]
+    for i in range(ncolors):
+        dc, c, s = fit_fiber_centering_parameters_one_color(hdul, color=i,
+                                                            xcent=xcent, ycent=ycent,
+                                                            plot=plot, nplots=ncolors)
+        dcs.append(dc)
+        cs.append(c)
+        seeing.append(s)
+        wavstring = hdul[3].header.get(f"Layer{i+1}").strip('nm')
+        wavs.append(float(wavstring))
+    if plot is True:
+        plt.show()
+
+    # print(f"Variation in centers = {min(cs):.1f} to {max(cs):.1f} = {max(cs)-min(cs):.1f} pix")
+    return cs, wavs, seeing
+
+def fit_2D_fiber_center(fgs_cube_fileX, fgs_cube_fileY, xcent=335.5, ycent=258.0, targname=None):
+    hdul = fits.open(fgs_cube_fileX)
+    fnmatch = re.match('TipTilt(\d{8})at(\d{6})_GridSearch.fits', fgs_cube_fileY.name)
+    if fnmatch is not None and targname is not None:
+        utdate = datetime.strptime(f"{fnmatch.group(1)} {fnmatch.group(2)}", "%Y%m%d %H%M%S")
+        ut_string = utdate.strftime('%Y-%m-%d %H:%M:%S')
+        pointing = SkyCoord.from_name(targname)
+        keck = EarthLocation.of_site('keck')
+        altazframe = AltAz(location=keck, obstime=utdate)
+        altaz = pointing.transform_to(altazframe)
+        va = float(hdul[0].header.get('VA'))
+
+    Xcenters, wavs, s = fit_fiber_centering_parameters(fgs_cube_fileX, xcent=xcent, plot=False, targname=targname)
+    if np.std(s) > 0.01:
+        print(f"Seeing varied during run: {s}")
+    Ycenters, wavs, s = fit_fiber_centering_parameters(fgs_cube_fileY, ycent=ycent, plot=False, targname=targname)
+    if np.std(s) > 0.01:
+        print(f"Seeing varied during run: {s}")
+    ncolors = len(Xcenters)-1
+    cstep = int(np.floor(256/ncolors))
+    
+    fig = plt.figure()
+    title = f"{ut_string} UT\n{targname}: EL={altaz.alt.deg:.1f} deg, VA={va:.1f} deg"
+    plt.title(title)
+    plt.plot([xcent, xcent], [ycent-2,ycent+2], 'k-')
+    plt.plot([xcent-3, xcent+3], [ycent,ycent], 'k-')
+    for i,center in enumerate(zip(Xcenters, Ycenters)):
+        if i == 0:
+            plt.plot(center[0], center[1], marker='o',
+                     color='k',
+                     label=f'{i}',
+                     alpha=0.5)            
+            arrow_length = 1
+            arrow_dx = -arrow_length*np.cos((va-90)*np.pi/180)
+            arrow_dy = -arrow_length*np.sin((va-90)*np.pi/180)
+            plt.arrow(center[0], center[1], arrow_dx, arrow_dy,
+                      head_width=arrow_length/5, color='k', alpha=0.2)
+        else:
+            try:
+                color = mpl.colormaps['bwr'](i*cstep)
+            except AttributeError as e:
+                from matplotlib import cm
+                color = cm.bwr(i*cstep)
+
+            plt.plot([center[0]], [center[1]], marker='o', linestyle='',
+                     color=color,
+                     label=f'{wavs[i]:.0f} nm',
+                     markersize=15, alpha=0.7)
+
+    plt.grid()
+    plt.xlabel('X pix')
+    plt.ylabel('Y pix')
+    plt.ylim(ycent-2,ycent+2)
+    plt.yticks(np.arange(ycent-2,ycent+2,1))
+    plt.xlim(xcent-3,xcent+3)
+    plt.xticks(np.arange(xcent-3,xcent+3,1))
+    fig.gca().set_aspect('equal', 'box')
+    plt.legend(loc='best')
+    plotfile = Path(f"{fgs_cube_fileX.name.replace('.fits', '.png').replace('TipTilt', '')}")
+    if plotfile.exists(): plotfile.unlink()
+    plt.savefig(f"{plotfile}", bbox_inches='tight', pad_inches=0.1)
+    plt.show()
+
+
+##-------------------------------------------------------------------------
+## Fit2DGridSearch
+##-------------------------------------------------------------------------
+class Fit2DGridSearch(KPFTranslatorFunction):
+    '''Take two 1D grid search runs (one in X and one in Y) ...
+    ARGS:
+    '''
+    @classmethod
+    def pre_condition(cls, args, logger, cfg):
+        pass
+
+    @classmethod
+    def perform(cls, args, logger, cfg):
+        fit_2D_fiber_center(Path(args.get('fgs_cube_fileX')),
+                            Path(args.get('fgs_cube_fileY')),
+                            xcent=args.get('xfit'),
+                            ycent=args.get('yfit'),
+                            targname=args.get('targname'))
+
+    @classmethod
+    def post_condition(cls, args, logger, cfg):
+        pass
+
+    @classmethod
+    def add_cmdline_args(cls, parser, cfg=None):
+        '''The arguments to add to the command line interface.
+        '''
+        parser.add_argument('fgs_cube_fileX', type=str,
+            help="The FGS FITS cube for the X pixel scan")
+        parser.add_argument('fgs_cube_fileY', type=str,
+            help="The FGS FITS cube for the Y pixel scan")
+        parser.add_argument('targname', type=str,
+            help="The target name")
+        parser.add_argument("--xfit", dest="xfit", type=float,
+            default=335.5,
+            help="The X pixel position to use as the center when overlaying the model.")
+        parser.add_argument("--yfit", dest="yfit", type=float,
+            default=258,
+            help="The X pixel position to use as the center when overlaying the model.")
+        return super().add_cmdline_args(parser, cfg)

--- a/kpf/analysis/Fit2DGridSearch.py
+++ b/kpf/analysis/Fit2DGridSearch.py
@@ -135,9 +135,13 @@ def fit_2D_fiber_center(fgs_cube_fileX, fgs_cube_fileY, xcent=335.5, ycent=258.0
         va = float(hdul[0].header.get('VA'))
 
     Xcenters, wavs, s = fit_fiber_centering_parameters(fgs_cube_fileX, xcent=xcent, plot=False, targname=targname)
+#     print(Xcenters, wavs, s)
+    print(f"X seeing = {np.mean(s):.1f}")
     if np.std(s) > 0.01:
         print(f"Seeing varied during run: {s}")
     Ycenters, wavs, s = fit_fiber_centering_parameters(fgs_cube_fileY, ycent=ycent, plot=False, targname=targname)
+#     print(Ycenters, wavs, s)
+    print(f"Y seeing = {np.mean(s):.1f}")
     if np.std(s) > 0.01:
         print(f"Seeing varied during run: {s}")
     ncolors = len(Xcenters)-1
@@ -148,28 +152,24 @@ def fit_2D_fiber_center(fgs_cube_fileX, fgs_cube_fileY, xcent=335.5, ycent=258.0
     plt.title(title)
     plt.plot([xcent, xcent], [ycent-2,ycent+2], 'k-')
     plt.plot([xcent-3, xcent+3], [ycent,ycent], 'k-')
-    for i,center in enumerate(zip(Xcenters, Ycenters)):
-        if i == 0:
-            plt.plot(center[0], center[1], marker='o',
-                     color='k',
-                     label=f'{i}',
-                     alpha=0.5)            
+
+    for i,center in enumerate(zip(Xcenters, Ycenters, wavs)):
+        xc, yc, wc = center
+        try:
+            color = mpl.colormaps['bwr'](i*cstep)
+        except AttributeError as e:
+            from matplotlib import cm
+            color = cm.bwr(i*cstep)
+        plt.plot([xc], [yc], marker='o', linestyle='',
+                 color=color,
+                 label=f'{wc:.0f} nm',
+                 markersize=15, alpha=0.7)
+        if np.isclose(wc, 550, atol=0.001):
             arrow_length = 1
             arrow_dx = -arrow_length*np.cos((va-90)*np.pi/180)
             arrow_dy = -arrow_length*np.sin((va-90)*np.pi/180)
-            plt.arrow(center[0], center[1], arrow_dx, arrow_dy,
+            plt.arrow(xc, yc, arrow_dx, arrow_dy,
                       head_width=arrow_length/5, color='k', alpha=0.2)
-        else:
-            try:
-                color = mpl.colormaps['bwr'](i*cstep)
-            except AttributeError as e:
-                from matplotlib import cm
-                color = cm.bwr(i*cstep)
-
-            plt.plot([center[0]], [center[1]], marker='o', linestyle='',
-                     color=color,
-                     label=f'{wavs[i]:.0f} nm',
-                     markersize=15, alpha=0.7)
 
     plt.grid()
     plt.xlabel('X pix')

--- a/kpf/analysis/Fit2DGridSearch.py
+++ b/kpf/analysis/Fit2DGridSearch.py
@@ -162,7 +162,7 @@ def fit_2D_fiber_center(fgs_cube_fileX, fgs_cube_fileY, xcent=335.5, ycent=258.0
             color = cm.bwr(i*cstep)
         plt.plot([xc], [yc], marker='o', linestyle='',
                  color=color,
-                 label=f'{wc:.0f} nm',
+                 label=f'{wc:.0f} nm ({xc:.1f}, {yc:.1f})',
                  markersize=15, alpha=0.7)
         if np.isclose(wc, 550, atol=0.001):
             arrow_length = 1

--- a/kpf/ao/SendPCUtoHome.py
+++ b/kpf/ao/SendPCUtoHome.py
@@ -19,7 +19,7 @@ class SendPCUtoHome(KPFTranslatorFunction):
 
     @classmethod
     def perform(cls, args, logger, cfg):
-        PCSstagekw = ktl.cache('ao', 'PCSFSTST')
+        PCSstagekw = ktl.cache('ao', 'PCSFNAME')
         log.info(f"Sending PCU to Home")
         PCSstagekw.write('home')
         shim_time = cfg.getfloat('times', 'ao_pcu_shim_time', fallback=5)

--- a/kpf/ao/SendPCUtoKPF.py
+++ b/kpf/ao/SendPCUtoKPF.py
@@ -25,7 +25,7 @@ class SendPCUtoKPF(KPFTranslatorFunction):
 
     @classmethod
     def perform(cls, args, logger, cfg):
-        PCSstagekw = ktl.cache('ao', 'PCSFSTST')
+        PCSstagekw = ktl.cache('ao', 'PCSFNAME')
         log.info(f"Sending PCU to KPF")
         PCSstagekw.write('kpf')
         shim_time = cfg.getfloat('times', 'ao_pcu_shim_time', fallback=5)

--- a/kpf/ao/SetupAOforKPF.py
+++ b/kpf/ao/SetupAOforKPF.py
@@ -50,11 +50,12 @@ class SetupAOforKPF(KPFTranslatorFunction):
         log.info('Turn K1 AO light source off')
         TurnLightSourceOff.execute({})
 
-        log.info('Move PCU to Home')
-        SendPCUtoHome.execute({})
-
-        log.info('Move PCU to KPF')
-        SendPCUtoKPF.execute({})
+        PCSstagekw = ktl.cache('ao', 'PCSFNAME')
+        if PCSstagekw.read() != 'kpf':
+            log.info('Move PCU to Home')
+            SendPCUtoHome.execute({})
+            log.info('Move PCU to KPF')
+            SendPCUtoKPF.execute({})
 
         log.info('Open AO hatch')
         ControlAOHatch.execute({'destination': 'open'})

--- a/kpf/calbench/IsCalSourceEnabled.py
+++ b/kpf/calbench/IsCalSourceEnabled.py
@@ -41,7 +41,7 @@ class IsCalSourceEnabled(KPFTranslatorFunction):
         if lamp_enabled is True:
             log.debug(f"Cal source {calsource} is enabled")
         else:
-            log.error(f"Cal source {calsource} is disabled")
+            log.warning(f"Cal source {calsource} is disabled")
         return lamp_enabled
 
     @classmethod

--- a/kpf/calbench/IsCalSourceEnabled.py
+++ b/kpf/calbench/IsCalSourceEnabled.py
@@ -1,0 +1,61 @@
+import ktl
+
+from kpf.KPFTranslatorFunction import KPFTranslatorFunction
+from kpf import (log, KPFException, FailedPreCondition, FailedPostCondition,
+                 FailedToReachDestination, check_input)
+from kpf.calbench import standardize_lamp_name
+
+
+class IsCalSourceEnabled(KPFTranslatorFunction):
+    '''Return a boolean indicating whether the input CalSource is enabled as
+    reported by the kpfconfig.%_ENABLED keywords.
+
+    ARGS:
+    =====
+    :CalSource: Which lamp to check?
+    '''
+    @classmethod
+    def pre_condition(cls, args, logger, cfg):
+        keyword = ktl.cache('kpfcal', 'OCTAGON')
+        allowed_values = list(keyword._getEnumerators())
+        if 'Unknown' in allowed_values:
+            allowed_values.pop(allowed_values.index('Unknown'))
+        allowed_values.append('SoCal-SciSky')
+        allowed_values.append('WideFlat')
+        check_input(args, 'CalSource', allowed_values=allowed_values)
+
+    @classmethod
+    def perform(cls, args, logger, cfg):
+        calsource = args.get('CalSource')
+        if calsource in ['BrdbandFiber', 'WideFlat', 'Th_daily', 'Th_gold', 'U_daily', 'U_gold']:
+            lamp_name = standardize_lamp_name(calsource)
+        elif calsource in ['LFCFiber', 'EtalonFiber']:
+            lamp_name = calsource.upper()
+        elif calsource in ['SoCal-CalFib', 'SoCal-SciSky']:
+            lamp_name = calsource.replace('-', '_').replace('Sky', 'FIB')
+        else:
+            log.warning(f"IsCalSourceEnabled does not recognize '{calsource}'")
+            return True
+        lamp_enabledkw = ktl.cache('kpfconfig', f'{lamp_name}_ENABLED')
+        lamp_enabled = lamp_enabledkw.read(binary=True)
+        if lamp_enabled is True:
+            log.debug(f"Cal source {calsource} is enabled")
+        else:
+            log.error(f"Cal source {calsource} is disabled")
+        return lamp_enabled
+
+    @classmethod
+    def post_condition(cls, args, logger, cfg):
+        pass
+
+    @classmethod
+    def add_cmdline_args(cls, parser, cfg=None):
+        '''The arguments to add to the command line interface.
+        '''
+        parser.add_argument('CalSource', type=str,
+                            choices=['BrdbandFiber', 'WideFlat', 'Th_daily',
+                                     'Th_gold', 'U_daily', 'U_gold',
+                                     'LFCFiber', 'EtalonFiber', 
+                                     'SoCal-CalFib', 'SoCal-SciSky'],
+                            help='Which lamp to check?')
+        return super().add_cmdline_args(parser, cfg)

--- a/kpf/calbench/SetLFCtoAstroComb.py
+++ b/kpf/calbench/SetLFCtoAstroComb.py
@@ -32,10 +32,21 @@ class SetLFCtoAstroComb(KPFTranslatorFunction):
 
     @classmethod
     def post_condition(cls, args, logger, cfg):
-        '''Verifies that kpfmon shows no errors.
         '''
+        '''
+        # Check kpfmon.LFCREADY
         LFCready = ktl.cache('kpfmon', 'LFCREADYSTA')
         timeout = cfg.getfloat('times', 'LFC_startup_time', fallback=60)
         success = LFCready.waitFor('== "OK"', timeout=timeout)
         if success is not True:
             raise FailedPostCondition('kpfmon.LFCREADYSTA is not OK')
+        # Check kpfcal.WOBBLE
+        wobble = ktl.cache('kpfcal', 'WOBBLE')
+        success = wobble.waitFor('== "False"', timeout=timeout)
+        if success is not True:
+            raise FailedPostCondition('kpfcal.WOBBLE is not False')
+        # Check kpfcal.OPERATIONMODE
+        lfc_mode = ktl.cache('kpfcal', 'OPERATIONMODE')
+        success = lfc_mode.waitFor('== "AstroComb"', timeout=timeout)
+        if success is not True:
+            raise FailedPostCondition('kpfcal.OPERATIONMODE is not AstroComb')

--- a/kpf/calbench/SetLFCtoAstroComb.py
+++ b/kpf/calbench/SetLFCtoAstroComb.py
@@ -17,7 +17,10 @@ class SetLFCtoAstroComb(KPFTranslatorFunction):
     '''
     @classmethod
     def pre_condition(cls, args, logger, cfg):
-        pass
+        heartbeat = ktl.cache('kpfmon', 'NE_HB_MENLO')
+        success = heartbeat.waitFor('== "OK"', timeout=3)
+        if success is False:
+            raise FailedPreCondition(f"Menlo heartbeat is not OK: {heartbeat.read()}")
 
     @classmethod
     def perform(cls, args, logger, cfg):
@@ -31,8 +34,8 @@ class SetLFCtoAstroComb(KPFTranslatorFunction):
     def post_condition(cls, args, logger, cfg):
         '''Verifies that kpfmon shows no errors.
         '''
-        expr = f"($kpfmon.LFCREADYSTA == 'OK')"
+        LFCready = ktl.cache('kpfmon', 'LFCREADYSTA')
         timeout = cfg.getfloat('times', 'LFC_startup_time', fallback=60)
-        success = ktl.waitFor(expr, timeout=timeout)
+        success = LFCready.waitFor('== "OK"', timeout=timeout)
         if success is not True:
             raise FailedPostCondition('kpfmon.LFCREADYSTA is not OK')

--- a/kpf/calbench/SetLFCtoAstroComb.py
+++ b/kpf/calbench/SetLFCtoAstroComb.py
@@ -17,7 +17,7 @@ class SetLFCtoAstroComb(KPFTranslatorFunction):
     '''
     @classmethod
     def pre_condition(cls, args, logger, cfg):
-        heartbeat = ktl.cache('kpfmon', 'NE_HB_MENLO')
+        heartbeat = ktl.cache('kpfmon', 'HB_MENLOSTA')
         success = heartbeat.waitFor('== "OK"', timeout=3)
         if success is False:
             raise FailedPreCondition(f"Menlo heartbeat is not OK: {heartbeat.read()}")

--- a/kpf/calbench/SetLFCtoStandbyHigh.py
+++ b/kpf/calbench/SetLFCtoStandbyHigh.py
@@ -17,7 +17,10 @@ class SetLFCtoStandbyHigh(KPFTranslatorFunction):
     '''
     @classmethod
     def pre_condition(cls, args, logger, cfg):
-        pass
+        heartbeat = ktl.cache('kpfmon', 'NE_HB_MENLO')
+        success = heartbeat.waitFor('== "OK"', timeout=3)
+        if success is False:
+            raise FailedPreCondition(f"Menlo heartbeat is not OK: {heartbeat.read()}")
 
     @classmethod
     def perform(cls, args, logger, cfg):
@@ -31,8 +34,8 @@ class SetLFCtoStandbyHigh(KPFTranslatorFunction):
     def post_condition(cls, args, logger, cfg):
         '''Verifies that kpfmon shows no errors.
         '''
-        expr = f"($kpfmon.LFCREADYSTA == 'OK')"
+        LFCready = ktl.cache('kpfmon', 'LFCREADYSTA')
         timeout = cfg.getfloat('times', 'LFC_startup_time', fallback=60)
-        success = ktl.waitFor(expr, timeout=timeout)
+        success = LFCready.waitFor('== "OK"', timeout=timeout)
         if success is not True:
             raise FailedPostCondition('kpfmon.LFCREADYSTA is not OK')

--- a/kpf/calbench/SetLFCtoStandbyHigh.py
+++ b/kpf/calbench/SetLFCtoStandbyHigh.py
@@ -17,7 +17,7 @@ class SetLFCtoStandbyHigh(KPFTranslatorFunction):
     '''
     @classmethod
     def pre_condition(cls, args, logger, cfg):
-        heartbeat = ktl.cache('kpfmon', 'NE_HB_MENLO')
+        heartbeat = ktl.cache('kpfmon', 'HB_MENLOSTA')
         success = heartbeat.waitFor('== "OK"', timeout=3)
         if success is False:
             raise FailedPreCondition(f"Menlo heartbeat is not OK: {heartbeat.read()}")

--- a/kpf/calbench/__init__.py
+++ b/kpf/calbench/__init__.py
@@ -18,8 +18,6 @@ def standardize_lamp_name(input_name):
     octagon_names = ['BrdbandFiber', 'U_gold', 'U_daily', 'Th_daily',
                      'Th_gold', 'WideFlat']
     '''
-    if input_name in [None, '']:
-        return None
     lamp_name = {'BrdbandFiber': 'BRDBANDFIBER',
                  'U_gold': 'U_GOLD',
                  'U_daily': 'U_DAILY',
@@ -31,11 +29,4 @@ def standardize_lamp_name(input_name):
                  'SciLED': 'SCILED',
                  'SkyLED': 'SKYLED',
                  }
-    if input_name not in lamp_name.keys():
-        return None
-    lamp = lamp_name.get(input_name)
-    allowed_lamps = ['EXPMLED', 'FF_FIBER', 'HKLED', 'BRDBANDFIBER', 'SCILED',
-                     'SKYLED', 'TH_DAILY', 'TH_GOLD', 'U_DAILY', 'U_GOLD']
-    if lamp not in allowed_lamps:
-        return None
-    return lamp
+    return lamp_name.get(input_name, None)

--- a/kpf/ddoi_configurations/kpf_inst_config.ini
+++ b/kpf/ddoi_configurations/kpf_inst_config.ini
@@ -44,7 +44,7 @@ guider_xpa_target = CRED2
 [times]
 ao_pcu_shim_time = 5
 ao_pcu_move_time = 150
-fiu_mode_shim_time = 2
+fiu_mode_shim_time = 5
 fiu_fold_mirror_move_time = 40
 fiu_hatch_move_time = 2
 fvc_command_timeout = 5

--- a/kpf/ddoi_configurations/kpf_inst_config.ini
+++ b/kpf/ddoi_configurations/kpf_inst_config.ini
@@ -52,6 +52,7 @@ octagon_move_time = 90
 nd_move_time = 20
 tip_tilt_move_time = 0.01
 tip_tilt_close_time = 3
+tip_tilt_max_attempt_time = 60
 slowest_readout_time = 120
 readout_buffer_time = 10
 lamp_response_time = 1

--- a/kpf/ddoi_configurations/kpf_inst_config.ini
+++ b/kpf/ddoi_configurations/kpf_inst_config.ini
@@ -44,7 +44,7 @@ guider_xpa_target = CRED2
 [times]
 ao_pcu_shim_time = 5
 ao_pcu_move_time = 150
-fiu_mode_shim_time = 5
+fiu_mode_shim_time = 10
 fiu_fold_mirror_move_time = 40
 fiu_hatch_move_time = 2
 fvc_command_timeout = 5

--- a/kpf/ddoi_configurations/kpf_inst_config.ini
+++ b/kpf/ddoi_configurations/kpf_inst_config.ini
@@ -73,6 +73,7 @@ max_exptime_for_guide_cube = 60
 green_detector_temperature_tolerance = 10
 red_detector_temperature_tolerance = 10
 cahk_detector_temperature_tolerance = 10
+expmeter_detector_temperature_tolerance = 0.5
 guider_exptime_tolerance = 0.01
 guider_fps_tolerance = 0.01
 fvc_exptime_tolerance = 0.01

--- a/kpf/ddoi_configurations/kpf_inst_config.ini
+++ b/kpf/ddoi_configurations/kpf_inst_config.ini
@@ -44,7 +44,7 @@ guider_xpa_target = CRED2
 [times]
 ao_pcu_shim_time = 5
 ao_pcu_move_time = 150
-fiu_mode_shim_time = 10
+fiu_mode_shim_time = 1
 fiu_fold_mirror_move_time = 40
 fiu_hatch_move_time = 2
 fvc_command_timeout = 5

--- a/kpf/expmeter/BuildMasterBias.py
+++ b/kpf/expmeter/BuildMasterBias.py
@@ -41,7 +41,14 @@ class BuildMasterBias(KPFTranslatorFunction):
         else:
             outputfile = Path(args.get('output')).expanduser()
         log.info(f"Writing {outputfile}")
-        fits.writeto(outputfile, median, overwrite=True)
+        hdu = fits.PrimaryHDU(data=median)
+        hdu.header.set('COMBTYPE', 'median', 'Combine type')
+        hdu.header.set('NCOMBINE', len(biasfiles), 'No. of individual biases')
+        for i,biasfile in enumerate(biasfiles):
+            hdu.header.set(f"INPUTF{i+1:02d}", biasfile.name,
+                           'One of the input files')
+        hdul = fits.HDUList([hdu])
+        hdul.writeto(outputfile,overwrite =True)
 
     @classmethod
     def post_condition(cls, args, logger, cfg):

--- a/kpf/expmeter/BuildMasterBias.py
+++ b/kpf/expmeter/BuildMasterBias.py
@@ -1,0 +1,32 @@
+import time
+import ktl
+
+from kpf.KPFTranslatorFunction import KPFTranslatorFunction
+from kpf import (log, KPFException, FailedPreCondition, FailedPostCondition,
+                 FailedToReachDestination, check_input)
+
+
+class BuildMasterBias(KPFTranslatorFunction):
+    '''
+    Args:
+    =====
+    :: 
+    '''
+    @classmethod
+    def pre_condition(cls, args, logger, cfg):
+        check_input(args, 'files', allowed_types=[list])
+
+    @classmethod
+    def perform(cls, args, logger, cfg):
+
+    @classmethod
+    def post_condition(cls, args, logger, cfg):
+        pass
+
+    @classmethod
+    def add_cmdline_args(cls, parser, cfg=None):
+        '''The arguments to add to the command line interface.
+        '''
+        parser.add_argument('files', nargs='*',
+                            help="The files to combine")
+        return super().add_cmdline_args(parser, cfg)

--- a/kpf/expmeter/BuildMasterBias.py
+++ b/kpf/expmeter/BuildMasterBias.py
@@ -1,5 +1,6 @@
 import time
 from pathlib import Path
+from datetime import datetime, timedelta
 import numpy as np
 from astropy.io import fits
 from astropy import stats
@@ -32,9 +33,11 @@ class BuildMasterBias(KPFTranslatorFunction):
         median = np.median(biases, axis=0)
         mean, med, std = stats.sigma_clipped_stats(median, sigma=2, maxiters=5)
         log.info(f"ExpMeter combined bias mean, med, std = {mean:.1f}, {med:.1f}, {std:.1f}")
-        
-        if args.get('output', None) is None:
-            outputfile = Path('~/combined_bias.fits').expanduser()
+
+        if args.get('output', None) in [None, '']:
+            utnow = datetime.utcnow()
+            now_str = utnow.strftime('%Y%m%dat%H%M%S')
+            outputfile = Path(f'/s/sdata1701/ExpMeterMasterFiles/MasterBias_{now_str}.fits')
         else:
             outputfile = Path(args.get('output')).expanduser()
         log.info(f"Writing {outputfile}")
@@ -51,6 +54,6 @@ class BuildMasterBias(KPFTranslatorFunction):
         parser.add_argument('files', nargs='*',
                             help="The files to combine")
         parser.add_argument("--output", dest="output", type=str,
-                            default='~/bias.fits',
+                            default='',
                             help="The output combined bias file.")
         return super().add_cmdline_args(parser, cfg)

--- a/kpf/expmeter/BuildMasterBias.py
+++ b/kpf/expmeter/BuildMasterBias.py
@@ -1,5 +1,8 @@
 import time
-import ktl
+from pathlib import Path
+import numpy as np
+from astropy.io import fits
+from astropy import stats
 
 from kpf.KPFTranslatorFunction import KPFTranslatorFunction
 from kpf import (log, KPFException, FailedPreCondition, FailedPostCondition,
@@ -18,6 +21,24 @@ class BuildMasterBias(KPFTranslatorFunction):
 
     @classmethod
     def perform(cls, args, logger, cfg):
+        biasfiles = args.get('files')
+        biasfiles = [Path(biasfile) for biasfile in biasfiles]
+        bias_hduls = [fits.open(f"{file}") for file in biasfiles]
+        biases = [hdul[0].data[:, 1:1069] for hdul in bias_hduls]
+        log.info(f"Combining {len(biasfiles)} ExpMeter bias frames")
+        for i,bias in enumerate(biases):
+            mean, med, std = stats.sigma_clipped_stats(bias, sigma=2, maxiters=5)
+            log.info(f"  {biasfiles[i].name}: mean, med, std = {mean:.1f}, {med:.1f}, {std:.1f}")
+        median = np.median(biases, axis=0)
+        mean, med, std = stats.sigma_clipped_stats(median, sigma=2, maxiters=5)
+        log.info(f"ExpMeter combined bias mean, med, std = {mean:.1f}, {med:.1f}, {std:.1f}")
+        
+        if args.get('output', None) is None:
+            outputfile = Path('~/combined_bias.fits').expanduser()
+        else:
+            outputfile = Path(args.get('output')).expanduser()
+        log.info(f"Writing {outputfile}")
+        fits.writeto(outputfile, median, overwrite=True)
 
     @classmethod
     def post_condition(cls, args, logger, cfg):
@@ -29,4 +50,7 @@ class BuildMasterBias(KPFTranslatorFunction):
         '''
         parser.add_argument('files', nargs='*',
                             help="The files to combine")
+        parser.add_argument("--output", dest="output", type=str,
+                            default='~/bias.fits',
+                            help="The output combined bias file.")
         return super().add_cmdline_args(parser, cfg)

--- a/kpf/expmeter/TakeExpMeterBiases.py
+++ b/kpf/expmeter/TakeExpMeterBiases.py
@@ -1,3 +1,4 @@
+import os
 import time
 from pathlib import Path
 

--- a/kpf/expmeter/TakeExpMeterBiases.py
+++ b/kpf/expmeter/TakeExpMeterBiases.py
@@ -7,6 +7,10 @@ from kpf.KPFTranslatorFunction import KPFTranslatorFunction
 from kpf import (log, KPFException, FailedPreCondition, FailedPostCondition,
                  FailedToReachDestination, check_input)
 from kpf.expmeter.BuildMasterBias import BuildMasterBias
+from kpf.calbench.SetCalSource import SetCalSource
+from kpf.calbench.WaitForCalSource import WaitForCalSource
+from kpf.spectrograph.SetSourceSelectShutters import SetSourceSelectShutters
+from kpf.spectrograph.WaitForReady import WaitForReady
 
 
 class TakeExpMeterBiases(KPFTranslatorFunction):
@@ -59,6 +63,12 @@ class TakeExpMeterBiases(KPFTranslatorFunction):
         kpf_expmeter['OBJECT'].write('bias')
         kpf_expmeter['OBSERVER'].write('TakeExpMeterBiases')
         kpf_expmeter['EXPMODE'].write('Continuous')
+
+        log.debug('Set Octagon to Home and close all source select shutters')
+        SetCalSource.execute({'CalSource': 'Home'})
+        WaitForReady.execute({})
+        SetSourceSelectShutters.execute({})
+        WaitForCalSource.execute({'CalSource': 'Home'})
 
         ready = kpf_expmeter['EXPSTATE'].waitFor("== 'Ready'", timeout=60)
         if ready is not True:

--- a/kpf/expmeter/TakeExpMeterBiases.py
+++ b/kpf/expmeter/TakeExpMeterBiases.py
@@ -134,6 +134,6 @@ class TakeExpMeterBiases(KPFTranslatorFunction):
                             default=False, action="store_true",
                             help="Combine the files in to a master bias?")
         parser.add_argument("--output", dest="output", type=str,
-                            default='~/bias.fits',
+                            default='',
                             help="The output combined bias file.")
         return super().add_cmdline_args(parser, cfg)

--- a/kpf/expmeter/TakeExpMeterBiases.py
+++ b/kpf/expmeter/TakeExpMeterBiases.py
@@ -1,0 +1,93 @@
+import time
+import ktl
+
+from kpf.KPFTranslatorFunction import KPFTranslatorFunction
+from kpf import (log, KPFException, FailedPreCondition, FailedPostCondition,
+                 FailedToReachDestination, check_input)
+
+
+class TakeExpMeterBiases(KPFTranslatorFunction):
+    '''Take a set of bias frames for the exposure meter.
+
+    Obeys kpfconfig.ALLOWSCHEDULEDCALS (will not run if that is set to No)
+
+    Args:
+    =====
+    :nExp: The number of frames to take
+    '''
+    @classmethod
+    def pre_condition(cls, args, logger, cfg):
+        check_input(args, 'nExp', allowed_types=[int])
+        kpf_expmeter = ktl.cache('kpf_expmeter')
+        # Check on exposure meter detector status
+        if kpf_expmeter['COOLING'].read(binary=True) != True:
+            raise FailedPreCondition('Exposure meter cooling is not On')
+        cooltarg = kpf_expmeter['COOLTARG'].read(binary=True)
+        currtemp = kpf_expmeter['CURRTEMP'].read(binary=True)
+        deltaT = abs(currtemp-cooltarg)
+        deltaT_threshold = cfg.getfloat('tolerances',
+                                'expmeter_detector_temperature_tolerance',
+                                fallback=0.5)
+        if deltaT > deltaT_threshold:
+            raise FailedPreCondition('Exposure meter not near target temperature')
+
+    @classmethod
+    def perform(cls, args, logger, cfg):
+        # Check if we're ok to take data
+        allowscheduledcals = ktl.cache('kpfconfig', 'ALLOWSCHEDULEDCALS')
+        if allowscheduledcals.read(binary=True) == False:
+            return []
+
+        # Proceed with taking biases
+        nExp = int(args.get('nExp'))
+        log.info(f"Taking {nExp} exposure meter bias frames")
+        kpf_expmeter = ktl.cache('kpf_expmeter')
+
+        # Set exposure meter to full frame to take biases
+        log.info(f"Setting exposure meter to full frame for biases")
+        kpf_expmeter['BINX'].write(1)
+        kpf_expmeter['BINY'].write(1)
+        kpf_expmeter['TOP'].write(0)
+        kpf_expmeter['LEFT'].write(0)
+        kpf_expmeter['WIDTH'].write(1072)
+        kpf_expmeter['HEIGHT'].write(1024)
+        kpf_expmeter['EXPOSURE'].write(0.12)
+        kpf_expmeter['OBJECT'].write('bias')
+
+        kpf_expmeter['EXPMODE'].write('Single')
+        biases = []
+        for i in nExp:
+            ready = kpf_expmeter['EXPSTATE'].waitFor("== 'Ready", timeout=60)
+            if ready is not True:
+                raise KPFError(f"Exposure Meter did not reach ready state")
+            log.debug(f"Taking bias {i+1}/{nExp}")
+            kpf_expmeter['EXPOSE'].write('Start')
+            kpf_expmeter['EXPSTATE'].waitFor("== 'Ready", timeout=5)
+            if ready is not True:
+                raise KPFError(f"Exposure Meter did not reach ready state")
+            lastfile = kpf_expmeter['FITSFILE'].read()
+            biases.append(lastfile)
+
+        # Set exposure meter back to operations settings
+        log.info(f"Setting exposure meter to operational windowing")
+        kpf_expmeter['BINX'].write(1)
+        kpf_expmeter['BINY'].write(1)
+        kpf_expmeter['TOP'].write(0)
+        kpf_expmeter['LEFT'].write(1)
+        kpf_expmeter['WIDTH'].write(651)
+        kpf_expmeter['HEIGHT'].write(300)
+        kpf_expmeter['OBJECT'].write('')
+
+        return biases
+
+    @classmethod
+    def post_condition(cls, args, logger, cfg):
+        pass
+
+    @classmethod
+    def add_cmdline_args(cls, parser, cfg=None):
+        '''The arguments to add to the command line interface.
+        '''
+        parser.add_argument('nExp', type=int,
+                            help="The number of frames to take")
+        return super().add_cmdline_args(parser, cfg)

--- a/kpf/expmeter/TakeExpMeterBiases.py
+++ b/kpf/expmeter/TakeExpMeterBiases.py
@@ -6,6 +6,8 @@ import ktl
 from kpf.KPFTranslatorFunction import KPFTranslatorFunction
 from kpf import (log, KPFException, FailedPreCondition, FailedPostCondition,
                  FailedToReachDestination, check_input)
+from kpf.scripts import (set_script_keywords, clear_script_keywords,
+                         add_script_log, check_script_running)
 from kpf.expmeter.BuildMasterBias import BuildMasterBias
 from kpf.calbench.SetCalSource import SetCalSource
 from kpf.calbench.WaitForCalSource import WaitForCalSource
@@ -23,6 +25,7 @@ class TakeExpMeterBiases(KPFTranslatorFunction):
     :nExp: The number of frames to take
     '''
     @classmethod
+    @obey_scriptrun
     def pre_condition(cls, args, logger, cfg):
         check_input(args, 'nExp', allowed_types=[int])
         kpf_expmeter = ktl.cache('kpf_expmeter')
@@ -39,6 +42,8 @@ class TakeExpMeterBiases(KPFTranslatorFunction):
             raise FailedPreCondition('Exposure meter not near target temperature')
 
     @classmethod
+    @register_script(Path(__file__).name, os.getpid())
+    @add_script_log(Path(__file__).name.replace(".py", ""))
     def perform(cls, args, logger, cfg):
         # Check if we're ok to take data
         allowscheduledcals = ktl.cache('kpfconfig', 'ALLOWSCHEDULEDCALS')

--- a/kpf/expmeter/TakeExpMeterBiases.py
+++ b/kpf/expmeter/TakeExpMeterBiases.py
@@ -6,8 +6,8 @@ import ktl
 from kpf.KPFTranslatorFunction import KPFTranslatorFunction
 from kpf import (log, KPFException, FailedPreCondition, FailedPostCondition,
                  FailedToReachDestination, check_input)
-from kpf.scripts import (set_script_keywords, clear_script_keywords,
-                         add_script_log, check_script_running)
+from kpf.scripts import (register_script, obey_scriptrun, check_scriptstop,
+                         add_script_log)
 from kpf.expmeter.BuildMasterBias import BuildMasterBias
 from kpf.calbench.SetCalSource import SetCalSource
 from kpf.calbench.WaitForCalSource import WaitForCalSource

--- a/kpf/fiu/ConfigureFIU.py
+++ b/kpf/fiu/ConfigureFIU.py
@@ -24,7 +24,7 @@ class ConfigureFIUOnce(KPFTranslatorFunction):
         kpffiu = ktl.cache('kpffiu')
         log.debug(f"Setting FIU mode to {dest}")
         kpffiu['MODE'].write(dest, wait=args.get('wait', True))
-        shim_time = cfg.getfloat('times', 'fiu_mode_shim_time', fallback=2)
+        shim_time = cfg.getfloat('times', 'fiu_mode_shim_time', fallback=5)
         time.sleep(shim_time)
 
     @classmethod

--- a/kpf/fiu/ConfigureFIU.py
+++ b/kpf/fiu/ConfigureFIU.py
@@ -3,7 +3,7 @@ import ktl
 
 from kpf.KPFTranslatorFunction import KPFTranslatorFunction
 from kpf import (log, KPFException, FailedPreCondition, FailedPostCondition,
-                 FailedToReachDestination, check_input, KPFQuietException)
+                 FailedToReachDestination, check_input)
 from kpf.fiu.ConfigureFIUOnce import ConfigureFIUOnce
 from kpf.fiu.WaitForConfigureFIU import WaitForConfigureFIU
 

--- a/kpf/fiu/ConfigureFIU.py
+++ b/kpf/fiu/ConfigureFIU.py
@@ -4,59 +4,17 @@ import ktl
 from kpf.KPFTranslatorFunction import KPFTranslatorFunction
 from kpf import (log, KPFException, FailedPreCondition, FailedPostCondition,
                  FailedToReachDestination, check_input, KPFQuietException)
-
-
-##-----------------------------------------------------------------------------
-## Configure FIU Once
-##-----------------------------------------------------------------------------
-class ConfigureFIUOnce(KPFTranslatorFunction):
-    '''Set the FIU mode (kpffiu.MODE) with a single attempt.
-    
-    This is intended to be wrapped by :py:func:`ConfigureFIU` to handle retries.
-    '''
-    @classmethod
-    def pre_condition(cls, args, logger, cfg):
-        return True
-
-    @classmethod
-    def perform(cls, args, logger, cfg):
-        dest = args.get('mode')
-        kpffiu = ktl.cache('kpffiu')
-        log.debug(f"Setting FIU mode to {dest}")
-        kpffiu['MODE'].write(dest, wait=args.get('wait', True))
-        shim_time = cfg.getfloat('times', 'fiu_mode_shim_time', fallback=5)
-        time.sleep(shim_time)
-        # Hack to check here and return result
-        # It seems like the CLI sees this exception even though it is caught by
-        # the ConfigureFIU code, so we'll not raise an exception and we'll
-        # instead return a status from this
-        modes = kpffiu['MODE'].read()
-        if dest.lower() not in modes.lower().split(','):
-            msg = f"FIU reached {modes} while trying to reach {dest}"
-            log.warning(msg)
-            return False
-        else:
-            return True
-
-    @classmethod
-    def post_condition(cls, args, logger, cfg):
-        pass
-#         dest = args.get('mode')
-#         kpffiu = ktl.cache('kpffiu')
-#         modes = kpffiu['MODE'].read()
-#         if dest.lower() not in modes.lower().split(','):
-#             msg = f"FIU reached {modes} while trying to reach {dest}"
-#             raise KPFQuietException(msg)
-#         return True
+from kpf.fiu.ConfigureFIUOnce import ConfigureFIUOnce
+from kpf.fiu.WaitForConfigureFIU import WaitForConfigureFIU
 
 
 ##-----------------------------------------------------------------------------
 ## Configure FIU
 ##-----------------------------------------------------------------------------
 class ConfigureFIU(KPFTranslatorFunction):
-    '''Set the FIU mode (kpffiu.MODE). This will retry if the first attempt
-    fails.
-    
+    '''Set the FIU mode (kpffiu.MODE). IF the wait option is fale this will
+    retry the move if it fails with a configurable number of retries.
+
     ARGS:
     =====
     :mode: The desired FIU mode.  One of:
@@ -74,36 +32,15 @@ class ConfigureFIU(KPFTranslatorFunction):
     @classmethod
     def perform(cls, args, logger, cfg):
         dest = args.get('mode')
-        ntries = cfg.getint('retries', 'fiu_mode_tries', fallback=2)
-        for i in range(ntries):
-            ok = ConfigureFIUOnce.execute({'mode': dest,
-                                           'wait': args.get('wait', True)})
-            if ok is False:
-                log.warning(f'FIU move failed on attempt {i+1} of {ntries}')
-                shim_time = cfg.getfloat('times', 'fiu_mode_shim_time', fallback=2)
-                time.sleep(shim_time)
-            else:
-                break
-#             try:
-#                 ConfigureFIUOnce.execute({'mode': dest,
-#                                           'wait': args.get('wait', True)})
-#             except KPFQuietException:
-#                 log.warning(f'FIU move failed on attempt {i+1} of {ntries}')
-#                 shim_time = cfg.getfloat('times', 'fiu_mode_shim_time', fallback=2)
-#                 time.sleep(shim_time)
-#             else:
-#                 break
+        wait = args.get('wait', True)
+        log.info(f"Configuring FIU for to {dest}")
+        ConfigureFIUOnce.execute({'mode': dest, 'wait': wait})
+        if wait == True:
+            WaitForConfigureFIU.execute({'mode': dest})
 
     @classmethod
     def post_condition(cls, args, logger, cfg):
-        if args.get('wait', True) is True:
-            dest = args.get('mode')
-            kpffiu = ktl.cache('kpffiu')
-            modes = kpffiu['MODE'].read()
-            if dest.lower() not in modes.lower().split(','):
-                raise FailedToReachDestination(dest, modes)
-            else:
-                log.info(f"FIU mode is now {dest}")
+        pass
 
     @classmethod
     def add_cmdline_args(cls, parser, cfg=None):

--- a/kpf/fiu/ConfigureFIUOnce.py
+++ b/kpf/fiu/ConfigureFIUOnce.py
@@ -3,7 +3,7 @@ import ktl
 
 from kpf.KPFTranslatorFunction import KPFTranslatorFunction
 from kpf import (log, KPFException, FailedPreCondition, FailedPostCondition,
-                 FailedToReachDestination, check_input, KPFQuietException)
+                 FailedToReachDestination, check_input)
 
 
 ##-----------------------------------------------------------------------------

--- a/kpf/fiu/ConfigureFIUOnce.py
+++ b/kpf/fiu/ConfigureFIUOnce.py
@@ -1,0 +1,36 @@
+import time
+import ktl
+
+from kpf.KPFTranslatorFunction import KPFTranslatorFunction
+from kpf import (log, KPFException, FailedPreCondition, FailedPostCondition,
+                 FailedToReachDestination, check_input, KPFQuietException)
+
+
+##-----------------------------------------------------------------------------
+## Configure FIU Once
+##-----------------------------------------------------------------------------
+class ConfigureFIUOnce(KPFTranslatorFunction):
+    '''Set the FIU mode (kpffiu.MODE) with a single attempt.
+    
+    This is intended to be wrapped by :py:func:`ConfigureFIU` to handle retries.
+    '''
+    @classmethod
+    def pre_condition(cls, args, logger, cfg):
+        keyword = ktl.cache('kpffiu', 'MODE')
+        allowed_values = list(keyword._getEnumerators())
+        if 'None' in allowed_values:
+            allowed_values.pop(allowed_values.index('None'))
+        check_input(args, 'mode', allowed_values=allowed_values)
+
+    @classmethod
+    def perform(cls, args, logger, cfg):
+        dest = args.get('mode')
+        fiumode = ktl.cache('kpffiu', 'MODE')
+        log.debug(f"Setting FIU mode to {dest}")
+        fiumode.write(dest, wait=args.get('wait', True))
+        shim_time = cfg.getfloat('times', 'fiu_mode_shim_time', fallback=1)
+        time.sleep(shim_time)
+
+    @classmethod
+    def post_condition(cls, args, logger, cfg):
+        pass

--- a/kpf/fiu/StartTipTilt.py
+++ b/kpf/fiu/StartTipTilt.py
@@ -31,17 +31,18 @@ class StartTipTilt(KPFTranslatorFunction):
 
     @classmethod
     def post_condition(cls, args, logger, cfg):
-        kpfguide = ktl.cache('kpfguide')
-        timeout = cfg.getfloat('times', 'tip_tilt_move_time', fallback=0.1)
-        expr = f"($kpfguide.TIPTILT_CALC == Active) "
-        success = ktl.waitFor(expr, timeout=timeout)
-        if success is False:
-            raise FailedToReachDestination(kpfguide['TIPTILT_CALC'].read(), 'Active')
-        expr = f"($kpfguide.TIPTILT_CONTROL == Active) "
-        success = ktl.waitFor(expr, timeout=timeout)
-        if success is False:
-            raise FailedToReachDestination(kpfguide['TIPTILT_CONTROL'].read(), 'Active')
-        expr = f"($kpfguide.OFFLOAD == Active) "
-        success = ktl.waitFor(expr, timeout=timeout)
-        if success is False:
-            raise FailedToReachDestination(kpfguide['OFFLOAD'].read(), 'Active')
+        pass
+#         kpfguide = ktl.cache('kpfguide')
+#         timeout = cfg.getfloat('times', 'tip_tilt_move_time', fallback=0.1)
+#         expr = f"($kpfguide.TIPTILT_CALC == Active) "
+#         success = ktl.waitFor(expr, timeout=timeout)
+#         if success is False:
+#             raise FailedToReachDestination(kpfguide['TIPTILT_CALC'].read(), 'Active')
+#         expr = f"($kpfguide.TIPTILT_CONTROL == Active) "
+#         success = ktl.waitFor(expr, timeout=timeout)
+#         if success is False:
+#             raise FailedToReachDestination(kpfguide['TIPTILT_CONTROL'].read(), 'Active')
+#         expr = f"($kpfguide.OFFLOAD == Active) "
+#         success = ktl.waitFor(expr, timeout=timeout)
+#         if success is False:
+#             raise FailedToReachDestination(kpfguide['OFFLOAD'].read(), 'Active')

--- a/kpf/fiu/StartTipTilt.py
+++ b/kpf/fiu/StartTipTilt.py
@@ -29,28 +29,6 @@ class StartTipTilt(KPFTranslatorFunction):
         log.info('Turning kpfguide.ALL_LOOPS on')
         kpfguide['ALL_LOOPS'].write('Active')
 
-        # Now see if we are locked on to the star consistently
-        # First, we wait a few seconds for TIPTILT_PHASE to become "tracking"
-        phase = ktl.cache('kpfguide' 'TIPTILT_PHASE')
-        loop_close_time = cfg.get('times', 'tip_tilt_close_time', fallback=3)
-        tracking = phase.waitFor('== Tracking', timeout=loop_close_time)
-        t0 = datetime.now()
-        if tracking == False:
-            raise LostTipTiltStar('Unable to obtain initial lock on star')
-        else:
-            log.debug('Obtained initial tip tilt lock')
-            # Second, wait a few seconds to see if we keep lock
-            max_attempt_time = cfg.get('times', 'tip_tilt_max_attempt_time', fallback=60)
-            lost_lock = phase.waitFor('!= Tracking', timeout=loop_close_time)
-            now = datetime.now()
-            # If we didn't hold on to the star, lets try a little while longer
-            while lost_lock == True and (now-t0).total_seconds() < max_attmpt_time:
-                log.debug(f'Lost lock, trying again')
-                lost_lock = phase.waitFor('!= Tracking', timeout=loop_close_time)
-        tracking = phase.waitFor('== Tracking', timeout=loop_close_time)
-        if tracking == False:
-            raise LostTipTiltStar('Unable to hold lock on star')
-
     @classmethod
     def post_condition(cls, args, logger, cfg):
         kpfguide = ktl.cache('kpfguide')

--- a/kpf/fiu/StopTipTilt.py
+++ b/kpf/fiu/StopTipTilt.py
@@ -26,17 +26,16 @@ class StopTipTilt(KPFTranslatorFunction):
 
     @classmethod
     def post_condition(cls, args, logger, cfg):
-        kpfguide = ktl.cache('kpfguide')
         timeout = cfg.getfloat('times', 'tip_tilt_move_time', fallback=0.1)
-        expr = f"($kpfguide.TIPTILT_CALC == Inactive) "
-        success = ktl.waitFor(expr, timeout=timeout)
+        TIPTILT_CALC = ktl.cache('kpfguide', 'TIPTILT_CALC')
+        success = TIPTILT_CALC.waitFor("== 'Inactive'")
         if success is False:
-            raise FailedToReachDestination(kpfguide['TIPTILT_CALC'].read(), 'Inactive')
-        expr = f"($kpfguide.TIPTILT_CONTROL == Inactive) "
-        success = ktl.waitFor(expr, timeout=timeout)
+            raise FailedToReachDestination(TIPTILT_CALC.read(), 'Inactive')
+        TIPTILT_CONTROL = ktl.cache('kpfguide', 'TIPTILT_CONTROL')
+        success = TIPTILT_CONTROL.waitFor("== 'Inactive'")
         if success is False:
-            raise FailedToReachDestination(kpfguide['TIPTILT_CONTROL'].read(), 'Inactive')
-        expr = f"($kpfguide.OFFLOAD == Inactive) "
-        success = ktl.waitFor(expr, timeout=timeout)
+            raise FailedToReachDestination(TIPTILT_CONTROL.read(), 'Inactive')
+        OFFLOAD = ktl.cache('kpfguide', 'OFFLOAD')
+        success = OFFLOAD.waitFor("== 'Inactive'")
         if success is False:
-            raise FailedToReachDestination(kpfguide['OFFLOAD'].read(), 'Inactive')
+            raise FailedToReachDestination(OFFLOAD.read(), 'Inactive')

--- a/kpf/fiu/WaitForTipTilt.py
+++ b/kpf/fiu/WaitForTipTilt.py
@@ -52,7 +52,7 @@ class WaitForTipTilt(KPFTranslatorFunction):
         # Now see if we are locked on to the star consistently
         # First, we wait a few seconds for TIPTILT_PHASE to become "tracking"
         phase = ktl.cache('kpfguide', 'TIPTILT_PHASE')
-        loop_close_time = cfg.get('times', 'tip_tilt_close_time', fallback=3)
+        loop_close_time = cfg.getfloat('times', 'tip_tilt_close_time', fallback=3)
         tracking = phase.waitFor('== "Tracking"', timeout=loop_close_time)
         t0 = datetime.now()
         if tracking == False:

--- a/kpf/fiu/WaitForTipTilt.py
+++ b/kpf/fiu/WaitForTipTilt.py
@@ -8,8 +8,36 @@ from kpf import (log, KPFException, FailedPreCondition, FailedPostCondition,
 
 
 class WaitForTipTilt(KPFTranslatorFunction):
-    '''
-    
+    '''Attempts to determine whether tip tilt loops have started successfully.
+
+    This logic is just meant to put some basic starting checks on the system to
+    see if it started up successfully before we initiate an observation. This
+    does not replace human monitoring of the loops during an exposure.
+
+    There are two time scales used here: tip_tilt_close_time and
+    tip_tilt_max_attempt_time:
+
+    tip_tilt_close_time is typically small (e.g. 3 seconds) an is there to make
+    sure that if the tracking phase becomes "tracking", this it isn't a
+    transitory event.
+
+    tip_tilt_max_attempt_time is typically larger (e.g. 60 seconds) and it is
+    how long the system will try to obtain a lock before giving up and erroring
+    out.
+
+    First, the system waits up to tip_tilt_close_time for the phase to become
+    "tracking".  If it is unable to attain the tracking state within that time,
+    it raises an error.
+
+    If we do attain an initial tracking lock, we want to see if the system holds
+    it and it was not transitory. To do so, the system will wait for one more
+    tip_tilt_close_time period and will declare success if the system does not
+    transition away from "tracking" during that period.
+
+    If we do lose lock during that period, it will keep trying to meet that
+    second criteria for a period of tip_tilt_max_attempt_time after the initial
+    tracking lock.
+
     ARGS:
     =====
     None
@@ -20,7 +48,8 @@ class WaitForTipTilt(KPFTranslatorFunction):
 
     @classmethod
     def perform(cls, args, logger, cfg):
-        # See if we are locked on to the star consistently
+
+        # Now see if we are locked on to the star consistently
         # First, we wait a few seconds for TIPTILT_PHASE to become "tracking"
         phase = ktl.cache('kpfguide' 'TIPTILT_PHASE')
         loop_close_time = cfg.get('times', 'tip_tilt_close_time', fallback=3)
@@ -28,25 +57,19 @@ class WaitForTipTilt(KPFTranslatorFunction):
         t0 = datetime.now()
         if tracking == False:
             raise LostTipTiltStar('Unable to obtain initial lock on star')
-        log.debug('Obtained initial tip tilt lock')
-
-        # Second, wait to see if we keep lock.
-        #   Keeping lock means that we are in the tracking state continuously
-        #   for a tip_tilt_close_time (e.g. 3 seconds)
-        max_time = cfg.get('times', 'tip_tilt_max_attempt_time', fallback=60)
-        lost_lock = phase.waitFor('!= Tracking', timeout=loop_close_time)
-        now = datetime.now()
-        # If we didn't hold lock on the star, lets try for a moderate time 
-        # (the tip_tilt_max_attempt_time) and see if we can hold it for a
-        # tip_tilt_close_time during that period.
-        while lost_lock == True and (now-t0).total_seconds() < max_time:
-            log.debug(f'Lost lock, trying again')
+        else:
+            log.debug('Obtained initial tip tilt lock')
+            # Second, wait a few seconds to see if we keep lock
+            max_attempt_time = cfg.get('times', 'tip_tilt_max_attempt_time', fallback=60)
             lost_lock = phase.waitFor('!= Tracking', timeout=loop_close_time)
             now = datetime.now()
+            # If we didn't hold on to the star, lets try a little while longer
+            while lost_lock == True and (now-t0).total_seconds() < max_attmpt_time:
+                log.debug(f'Lost lock, trying again')
+                lost_lock = phase.waitFor('!= Tracking', timeout=loop_close_time)
 
         # Double check we are tracking before moving on
-        tracking = phase.waitFor('== Tracking', timeout=loop_close_time)
-        if tracking == False:
+        if lost_lock == True:
             raise LostTipTiltStar('Unable to hold lock on star')
 
     @classmethod

--- a/kpf/fiu/WaitForTipTilt.py
+++ b/kpf/fiu/WaitForTipTilt.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 
 import ktl
 
-from ddoitranslatormodule.KPFTranslatorFunction import KPFTranslatorFunction
+from kpf.KPFTranslatorFunction import KPFTranslatorFunction
 from kpf import (log, KPFException, FailedPreCondition, FailedPostCondition,
                  FailedToReachDestination, check_input, LostTipTiltStar)
 

--- a/kpf/fiu/WaitForTipTilt.py
+++ b/kpf/fiu/WaitForTipTilt.py
@@ -60,7 +60,7 @@ class WaitForTipTilt(KPFTranslatorFunction):
         else:
             log.debug('Obtained initial tip tilt lock')
             # Second, wait a few seconds to see if we keep lock
-            max_attempt_time = cfg.get('times', 'tip_tilt_max_attempt_time', fallback=60)
+            max_attempt_time = cfg.getfloat('times', 'tip_tilt_max_attempt_time', fallback=60)
             lost_lock = phase.waitFor('!= Tracking', timeout=loop_close_time)
             now = datetime.now()
             # If we didn't hold on to the star, lets try a little while longer

--- a/kpf/fiu/WaitForTipTilt.py
+++ b/kpf/fiu/WaitForTipTilt.py
@@ -30,11 +30,15 @@ class WaitForTipTilt(KPFTranslatorFunction):
             raise LostTipTiltStar('Unable to obtain initial lock on star')
         log.debug('Obtained initial tip tilt lock')
 
-        # Second, wait a few seconds to see if we keep lock
+        # Second, wait to see if we keep lock.
+        #   Keeping lock means that we are in the tracking state continuously
+        #   for a tip_tilt_close_time (e.g. 3 seconds)
         max_time = cfg.get('times', 'tip_tilt_max_attempt_time', fallback=60)
         lost_lock = phase.waitFor('!= Tracking', timeout=loop_close_time)
         now = datetime.now()
-        # If we didn't hold on to the star, lets try a little while longer
+        # If we didn't hold lock on the star, lets try for a moderate time 
+        # (the tip_tilt_max_attempt_time) and see if we can hold it for a
+        # tip_tilt_close_time during that period.
         while lost_lock == True and (now-t0).total_seconds() < max_time:
             log.debug(f'Lost lock, trying again')
             lost_lock = phase.waitFor('!= Tracking', timeout=loop_close_time)

--- a/kpf/fiu/WaitForTipTilt.py
+++ b/kpf/fiu/WaitForTipTilt.py
@@ -53,7 +53,7 @@ class WaitForTipTilt(KPFTranslatorFunction):
         # First, we wait a few seconds for TIPTILT_PHASE to become "tracking"
         phase = ktl.cache('kpfguide', 'TIPTILT_PHASE')
         loop_close_time = cfg.get('times', 'tip_tilt_close_time', fallback=3)
-        tracking = phase.waitFor('== Tracking', timeout=loop_close_time)
+        tracking = phase.waitFor('== "Tracking"', timeout=loop_close_time)
         t0 = datetime.now()
         if tracking == False:
             raise LostTipTiltStar('Unable to obtain initial lock on star')

--- a/kpf/fiu/WaitForTipTilt.py
+++ b/kpf/fiu/WaitForTipTilt.py
@@ -7,7 +7,27 @@ from kpf import (log, KPFException, FailedPreCondition, FailedPostCondition,
                  FailedToReachDestination, check_input, LostTipTiltStar)
 
 
+
 class WaitForTipTilt(KPFTranslatorFunction):
+    '''Dumb versions which simply waits for a few seconds.
+
+    ARGS:
+    =====
+    None
+    '''
+    @classmethod
+    def pre_condition(cls, args, logger, cfg):
+        pass
+    @classmethod
+    def perform(cls, args, logger, cfg):
+        loop_close_time = cfg.getfloat('times', 'tip_tilt_close_time', fallback=3)
+        time.sleep(loop_close_time)
+
+    @classmethod
+    def post_condition(cls, args, logger, cfg):
+        pass
+
+class WaitForTipTilt_usephase(KPFTranslatorFunction):
     '''Attempts to determine whether tip tilt loops have started successfully.
 
     This logic is just meant to put some basic starting checks on the system to
@@ -44,7 +64,7 @@ class WaitForTipTilt(KPFTranslatorFunction):
     '''
     @classmethod
     def pre_condition(cls, args, logger, cfg):
-        return True
+        pass
 
     @classmethod
     def perform(cls, args, logger, cfg):

--- a/kpf/fiu/WaitForTipTilt.py
+++ b/kpf/fiu/WaitForTipTilt.py
@@ -51,7 +51,7 @@ class WaitForTipTilt(KPFTranslatorFunction):
 
         # Now see if we are locked on to the star consistently
         # First, we wait a few seconds for TIPTILT_PHASE to become "tracking"
-        phase = ktl.cache('kpfguide' 'TIPTILT_PHASE')
+        phase = ktl.cache('kpfguide', 'TIPTILT_PHASE')
         loop_close_time = cfg.get('times', 'tip_tilt_close_time', fallback=3)
         tracking = phase.waitFor('== Tracking', timeout=loop_close_time)
         t0 = datetime.now()

--- a/kpf/fiu/WaitForTipTilt.py
+++ b/kpf/fiu/WaitForTipTilt.py
@@ -64,7 +64,7 @@ class WaitForTipTilt(KPFTranslatorFunction):
             lost_lock = phase.waitFor('!= Tracking', timeout=loop_close_time)
             now = datetime.now()
             # If we didn't hold on to the star, lets try a little while longer
-            while lost_lock == True and (now-t0).total_seconds() < max_attmpt_time:
+            while lost_lock == True and (now-t0).total_seconds() < max_attempt_time:
                 log.debug(f'Lost lock, trying again')
                 lost_lock = phase.waitFor('!= Tracking', timeout=loop_close_time)
 

--- a/kpf/fiu/WaitForTipTilt.py
+++ b/kpf/fiu/WaitForTipTilt.py
@@ -51,4 +51,4 @@ class WaitForTipTilt(KPFTranslatorFunction):
 
     @classmethod
     def post_condition(cls, args, logger, cfg):
-        return True
+        pass

--- a/kpf/fiu/WaitForTipTilt.py
+++ b/kpf/fiu/WaitForTipTilt.py
@@ -1,3 +1,4 @@
+import time
 from datetime import datetime, timedelta
 
 import ktl

--- a/kpf/fvc/FVCPower.py
+++ b/kpf/fvc/FVCPower.py
@@ -14,58 +14,42 @@ class FVCPower(KPFTranslatorFunction):
     
     ARGS:
     =====
-    :camera: Which FVC camera (SCI, CAHK, EXT, CAL)?
+    :camera: Which FVC camera (SCI, CAHK, CAL)?
     :power: Desired state: on or off
     '''
     @classmethod
     def pre_condition(cls, args, logger, cfg):
-        camera = args.get('camera')
-        cameras = {'SCI': 1, 'CAHK': 2, 'CAL': 3}
-        camnum = cameras[camera]
-        if camera not in cameras.keys():
-            raise FailedPreCondition(f"Input camera {camera} not in allowed values")
-        kpfpower = ktl.cache('kpfpower')
-        outlet = kpfpower[f"KPFFVC{camnum}_OUTLETS"].read().strip('kpfpower.')
-        outletname = kpfpower[f"{outlet}_NAME"].read()
-        if re.search(f"fvc{camnum}", outletname) is None:
-            raise FailedPreCondition(f"Outlet name error: expected "
-                                     f"'fvc{camnum}' in '{outletname}'")
-        locked = kpfpower[f"{outlet}_LOCK"].read() == 'Locked'
-        if locked is True:
-            raise FailedPreCondition(f"Outlet is locked")
+        check_input(args, 'camera', allowed_values=['SCI', 'CAHK', 'CAL'])
 
     @classmethod
     def perform(cls, args, logger, cfg):
         camera = args.get('camera')
         camnum = {'SCI': 1, 'CAHK': 2, 'CAL': 3}[camera]
-        pwr = args.get('power')
-        kpfpower = ktl.cache('kpfpower')
-        outlet = kpfpower[f"KPFFVC{camnum}_OUTLETS"].read().strip('kpfpower.')
-        outletname = kpfpower[f"{outlet}_NAME"].read()
-        log.debug(f"Turning {pwr} {camera} FVC (outlet {outlet}: {outletname})")
-        kpfpower[f"KPFFVC{camnum}"].write(pwr)
-        shim = cfg.getfloat('times', 'fvc_command_timeshim', fallback=2)
-        time.sleep(shim)
+        powerkw = ktl.cache('kpfpower', f'KPFFVC{camnum}')
+        dest = args.get('power')
+        if powerkw.read().lower() != dest.lower():
+            log.info(f"Turning {dest} {camera} FVC")
+            powerkw.write(args.get('power'))
+            shim = cfg.getfloat('times', 'fvc_command_timeshim', fallback=2)
+            time.sleep(shim)
 
     @classmethod
     def post_condition(cls, args, logger, cfg):
         camera = args.get('camera')
-        cameras = {'SCI': 1, 'CAHK': 2, 'CAL': 3}
-        camnum = cameras[camera]
-        kpfpower = ktl.cache('kpfpower')
-        outlet = kpfpower[f"KPFFVC{camnum}_OUTLETS"].read().strip('kpfpower.')
-        pwr = args.get('power')
+        camnum = {'SCI': 1, 'CAHK': 2, 'CAL': 3}[camera]
+        powerkw = ktl.cache('kpfpower', f'KPFFVC{camnum}')
         timeout = cfg.getfloat('times', 'fvc_command_timeout', fallback=1)
-        success = ktl.waitFor(f"($kpfpower.{outlet} == {pwr})", timeout=timeout)
+        dest = args.get('power')
+        success = powerkw.waitFor(f"== '{dest}'", timeout=timeout)
         if success is False:
-            raise FailedToReachDestination(kpfpower[outlet].read(), pwr)
+            raise FailedToReachDestination(powerkw.read(), dest)
 
     @classmethod
     def add_cmdline_args(cls, parser, cfg=None):
         '''The arguments to add to the command line interface.
         '''
         parser.add_argument('camera', type=str,
-                            choices=['SCI', 'CAHK', 'CAL', 'EXT'],
+                            choices=['SCI', 'CAHK', 'CAL'],
                             help='The FVC camera')
         parser.add_argument('power', type=str,
                             choices=['on', 'off'],

--- a/kpf/fvc/FVCPower.py
+++ b/kpf/fvc/FVCPower.py
@@ -44,7 +44,8 @@ class FVCPower(KPFTranslatorFunction):
         outletname = kpfpower[f"{outlet}_NAME"].read()
         log.debug(f"Turning {pwr} {camera} FVC (outlet {outlet}: {outletname})")
         kpfpower[f"KPFFVC{camnum}"].write(pwr)
-        time.sleep(1)
+        shim = cfg.getfloat('times', 'fvc_command_timeshim', fallback=2)
+        time.sleep(shim)
 
     @classmethod
     def post_condition(cls, args, logger, cfg):
@@ -54,7 +55,7 @@ class FVCPower(KPFTranslatorFunction):
         kpfpower = ktl.cache('kpfpower')
         outlet = kpfpower[f"KPFFVC{camnum}_OUTLETS"].read().strip('kpfpower.')
         pwr = args.get('power')
-        timeout = cfg.getfloat('times', 'lamp_response_time', fallback=1)
+        timeout = cfg.getfloat('times', 'fvc_command_timeout', fallback=1)
         success = ktl.waitFor(f"($kpfpower.{outlet} == {pwr})", timeout=timeout)
         if success is False:
             raise FailedToReachDestination(kpfpower[outlet].read(), pwr)

--- a/kpf/fvc/PredictFVCParameters.py
+++ b/kpf/fvc/PredictFVCParameters.py
@@ -1,0 +1,64 @@
+from kpf.KPFTranslatorFunction import KPFTranslatorFunction
+from kpf import (log, KPFException, FailedPreCondition, FailedPostCondition,
+                 FailedToReachDestination, check_input)
+from kpf.fvc.SetFVCExpTime import SetFVCExpTime
+
+
+class PredictFVCParameters(KPFTranslatorFunction):
+    '''Estimate the exposure time given the stellar Jmag and which camera.
+
+    Based on scaling from a single, poorly measured data point:
+    For Vmag ~ 4, the SCIFVC_exptime = 1 and CAHKFVC_exptime = 15
+
+    Args:
+    =====
+    :Gmag: The G magnitude of the target
+    '''
+    @classmethod
+    def pre_condition(cls, args, logger, cfg):
+        check_input(args, 'Gmag', allowed_types=[int, float])
+
+    @classmethod
+    def perform(cls, args, logger, cfg):
+        Gmag = args.get('Gmag')
+        camera = args.get('camera')
+        delta_mag = 4 - Gmag
+        flux_ratio = 10**(delta_mag/2.5)
+        if flux_ratio > 10:
+            exptime = {'SCI': 0.1,
+                       'CAHK': 1.5}
+        elif flux_ratio > 5:
+            exptime = {'SCI': 0.2,
+                       'CAHK': 3}
+        elif flux_ratio > 2:
+            exptime = {'SCI': 0.5,
+                       'CAHK': 8}
+        elif flux_ratio > 0.5:
+            exptime = {'SCI': 1,
+                       'CAHK': 15}
+        elif flux_ratio > 0.2:
+            exptime = {'SCI': 5,
+                       'CAHK': 15}
+        elif flux_ratio > 0.05:
+            exptime = {'SCI': 10,
+                       'CAHK': 15}
+        result = {'camera': camera, 'exptime': exptime[camera]}
+        print(result)
+        if args.get('set', False):
+            SetFVCExpTime.execute(result)
+        return result
+
+    @classmethod
+    def post_condition(cls, args, logger, cfg):
+        pass
+
+    @classmethod
+    def add_cmdline_args(cls, parser, cfg=None):
+        parser.add_argument('camera', type=str,
+                            help='The FVC camera (SCI, CAHK)')
+        parser.add_argument('Gmag', type=float,
+                            help="The G magnitude of the target")
+        parser.add_argument("--set", dest="set",
+            default=False, action="store_true",
+            help="Set these values after calculating?")
+        return super().add_cmdline_args(parser, cfg)

--- a/kpf/fvc/PredictFVCParameters.py
+++ b/kpf/fvc/PredictFVCParameters.py
@@ -16,6 +16,7 @@ class PredictFVCParameters(KPFTranslatorFunction):
     '''
     @classmethod
     def pre_condition(cls, args, logger, cfg):
+        check_input(args, 'camera', allowed_values=['SCI', 'CAHK']])
         check_input(args, 'Gmag', allowed_types=[int, float])
 
     @classmethod

--- a/kpf/fvc/PredictFVCParameters.py
+++ b/kpf/fvc/PredictFVCParameters.py
@@ -16,13 +16,11 @@ class PredictFVCParameters(KPFTranslatorFunction):
     '''
     @classmethod
     def pre_condition(cls, args, logger, cfg):
-        check_input(args, 'camera', allowed_values=['SCI', 'CAHK']])
         check_input(args, 'Gmag', allowed_types=[int, float])
 
     @classmethod
     def perform(cls, args, logger, cfg):
         Gmag = args.get('Gmag')
-        camera = args.get('camera')
         delta_mag = 4 - Gmag
         flux_ratio = 10**(delta_mag/2.5)
         if flux_ratio > 10:
@@ -43,10 +41,12 @@ class PredictFVCParameters(KPFTranslatorFunction):
         elif flux_ratio > 0.05:
             exptime = {'SCI': 10,
                        'CAHK': 15}
-        result = {'camera': camera, 'exptime': exptime[camera]}
+        result = {'SCIFVC_exptime': exptime['SCI'],
+                  'CAHKFVC_exptime': exptime['CAHK']}
         print(result)
         if args.get('set', False):
-            SetFVCExpTime.execute(result)
+            SetFVCExpTime.execute({'camera': 'SCI', 'exptime': exptime['SCI']})
+            SetFVCExpTime.execute({'camera': 'CAHK', 'exptime': exptime['CAHK']})
         return result
 
     @classmethod
@@ -55,8 +55,6 @@ class PredictFVCParameters(KPFTranslatorFunction):
 
     @classmethod
     def add_cmdline_args(cls, parser, cfg=None):
-        parser.add_argument('camera', type=str,
-                            help='The FVC camera (SCI, CAHK)')
         parser.add_argument('Gmag', type=float,
                             help="The G magnitude of the target")
         parser.add_argument("--set", dest="set",

--- a/kpf/fvc/SetFVCExpTime.py
+++ b/kpf/fvc/SetFVCExpTime.py
@@ -19,6 +19,12 @@ class SetFVCExpTime(KPFTranslatorFunction):
     def pre_condition(cls, args, logger, cfg):
         check_input(args, 'camera', allowed_values=['SCI', 'CAHK', 'CAL', 'EXT'])
         check_input(args, 'exptime', value_min=0.001, value_max=60)
+        # Check if power is on
+        camera = args.get('camera')
+        camnum = {'SCI': 1, 'CAHK': 2, 'CAL': 3}[camera]
+        powerkw = ktl.cache('kpfpower', f"KPFFVC{camnum}")
+        if powerkw.read() != 'On':
+            raise FailedPreCondition(f"{camera}FVC power is not On")
 
     @classmethod
     def perform(cls, args, logger, cfg):

--- a/kpf/fvc/TakeFVCContinuous.py
+++ b/kpf/fvc/TakeFVCContinuous.py
@@ -22,6 +22,12 @@ class TakeFVCContinuous(KPFTranslatorFunction):
     @classmethod
     def pre_condition(cls, args, logger, cfg):
         check_input(args, 'camera', allowed_values=['SCI', 'CAHK', 'CAL', 'EXT'])
+        # Check if power is on
+        camera = args.get('camera')
+        camnum = {'SCI': 1, 'CAHK': 2, 'CAL': 3}[camera]
+        powerkw = ktl.cache('kpfpower', f"KPFFVC{camnum}")
+        if powerkw.read() != 'On':
+            raise FailedPreCondition(f"{camera}FVC power is not On")
 
     @classmethod
     def perform(cls, args, logger, cfg):

--- a/kpf/fvc/TakeFVCExposure.py
+++ b/kpf/fvc/TakeFVCExposure.py
@@ -21,6 +21,12 @@ class TakeFVCExposure(KPFTranslatorFunction):
     @classmethod
     def pre_condition(cls, args, logger, cfg):
         check_input(args, 'camera', allowed_values=['SCI', 'CAHK', 'CAL', 'EXT'])
+        # Check if power is on
+        camera = args.get('camera')
+        camnum = {'SCI': 1, 'CAHK': 2, 'CAL': 3}[camera]
+        powerkw = ktl.cache('kpfpower', f"KPFFVC{camnum}")
+        if powerkw.read() != 'On':
+            raise FailedPreCondition(f"{camera}FVC power is not On")
 
     @classmethod
     def perform(cls, args, logger, cfg):

--- a/kpf/fvc/TakeFVCExposure.py
+++ b/kpf/fvc/TakeFVCExposure.py
@@ -53,6 +53,7 @@ class TakeFVCExposure(KPFTranslatorFunction):
                               f"{regfile}"]
                 log.debug(f"Running: {' '.join(overlaycmd)}")
                 subprocess.call(' '.join(overlaycmd), shell=True)
+        return kpffvc[f"{camera}LASTFILE"].read()
 
     @classmethod
     def post_condition(cls, args, logger, cfg):

--- a/kpf/guider/PredictGuiderParameters.py
+++ b/kpf/guider/PredictGuiderParameters.py
@@ -1,6 +1,9 @@
 from kpf.KPFTranslatorFunction import KPFTranslatorFunction
 from kpf import (log, KPFException, FailedPreCondition, FailedPostCondition,
                  FailedToReachDestination, check_input)
+from kpf.guider.SetGuiderGain import SetGuiderGain
+from kpf.guider.SetGuiderFPS import SetGuiderFPS
+
 
 # Engineering OBs (not consistent)
 # Jmag, Gain
@@ -54,7 +57,11 @@ class PredictGuiderParameters(KPFTranslatorFunction):
             fps = 10
         log.info(f"Predicted GuideCamGain = {gain}")
         log.info(f"Predicted GuideFPS = {fps:d}")
-        return {'GuideCamGain': gain, 'GuideFPS': fps}
+        result = {'GuideCamGain': gain, 'GuideFPS': fps}
+        if args.get('set', False):
+            SetGuiderGain.execute(result)
+            SetGuiderFPS.execute(result)
+        return result
 
     @classmethod
     def post_condition(cls, args, logger, cfg):
@@ -64,4 +71,7 @@ class PredictGuiderParameters(KPFTranslatorFunction):
     def add_cmdline_args(cls, parser, cfg=None):
         parser.add_argument('Jmag', type=float,
                             help="The J magnitude of the target")
+        parser.add_argument("--set", dest="set",
+            default=False, action="store_true",
+            help="Set these values after calculating?")
         return super().add_cmdline_args(parser, cfg)

--- a/kpf/guider/PredictGuiderParameters.py
+++ b/kpf/guider/PredictGuiderParameters.py
@@ -37,7 +37,7 @@ class PredictGuiderParameters(KPFTranslatorFunction):
     @classmethod
     def perform(cls, args, logger, cfg):
         Jmag = args.get('Jmag')
-        if Jmag < 5.0:
+        if Jmag < 5.5:
             gain = 'low'
             fps = 100
         elif Jmag < 8.0:

--- a/kpf/guider/PredictGuiderParameters.py
+++ b/kpf/guider/PredictGuiderParameters.py
@@ -43,15 +43,18 @@ class PredictGuiderParameters(KPFTranslatorFunction):
         elif Jmag < 8.0:
             gain = 'medium'
             fps = 100
-        elif Jmag < 11.5:
+        elif Jmag < 12.0:
             gain = 'high'
             fps = 100
-        elif Jmag < 12.5:
+        elif Jmag < 12.8:
             gain = 'high'
             fps = 50
-        elif Jmag < 13.5:
+        elif Jmag < 13.8:
             gain = 'high'
             fps = 20
+        elif Jmag < 14.5:
+            gain = 'high'
+            fps = 10
         else:
             gain = 'high'
             fps = 10

--- a/kpf/guider/TakeGuiderCube.py
+++ b/kpf/guider/TakeGuiderCube.py
@@ -34,7 +34,7 @@ class TakeGuiderCube(KPFTranslatorFunction):
         initial_all_loops = kpfguide['ALL_LOOPS'].read()
 
         # Do we want to take the image cube?
-        collect_image_cube = args.get('ImageCube', False)
+        collect_image_cube = args.get('ImageCube', True)
         set_trigcube = {True: 'Active', False: 'Inactive'}[collect_image_cube]
         kpfguide['TRIGCUBE'].write(set_trigcube)
 

--- a/kpf/guider/TakeGuiderCube.py
+++ b/kpf/guider/TakeGuiderCube.py
@@ -63,7 +63,7 @@ class TakeGuiderCube(KPFTranslatorFunction):
         '''
         parser.add_argument('duration', type=float,
                             help='The duration in seconds')
-        parser.add_argument("--ImageCube", dest="ImageCube",
+        parser.add_argument("--noTRIGCUBE", dest="ImageCube",
                             default=True, action="store_false",
                             help="Collect the full image cube?")
         return super().add_cmdline_args(parser, cfg)

--- a/kpf/linking_table.yml
+++ b/kpf/linking_table.yml
@@ -164,8 +164,8 @@ links:
         cmd: scripts.ExecuteSciSequence.ExecuteSciSequence
     GridSearch:
         cmd: scripts.GridSearch.GridSearch
-    FiberGridSearch:
-        cmd: scripts.FiberGridSearch.FiberGridSearch
+    Run2DGridSearch:
+        cmd: scripts.Run2DGridSearch.Run2DGridSearch
     RunCalOB:
         cmd: scripts.RunCalOB.RunCalOB
     RunSciOB:

--- a/kpf/linking_table.yml
+++ b/kpf/linking_table.yml
@@ -93,6 +93,8 @@ links:
         cmd: fiu.TestTipTiltMirrorRange.TestTipTiltMirrorRange
     WaitForConfigureFIU:
         cmd: fiu.WaitForConfigureFIU.WaitForConfigureFIU
+    WaitForTipTilt:
+        cmd: fiu.WaitForTipTilt.WaitForTipTilt
     # FVCs
     FVCPower:
         cmd: fvc.FVCPower.FVCPower

--- a/kpf/linking_table.yml
+++ b/kpf/linking_table.yml
@@ -8,6 +8,8 @@ links:
         cmd: analysis.AnalyzeGridSearch.AnalyzeGridSearch
     AnalyzeGuideCube:
         cmd: analysis.AnalyzeGuideCube.AnalyzeGuideCube
+    Fit2DGridSearch:
+        cmd: analysis.Fit2DGridSearch.Fit2DGridSearch
     # AO
     ControlAOHatch:
         cmd: ao.ControlAOHatch.ControlAOHatch

--- a/kpf/linking_table.yml
+++ b/kpf/linking_table.yml
@@ -4,6 +4,10 @@ common:
 
 links:
     # Analysis
+    AnalyzeGridSearch:
+        cmd: analysis.AnalyzeGridSearch.AnalyzeGridSearch
+    AnalyzeGuideCube:
+        cmd: analysis.AnalyzeGuideCube.AnalyzeGuideCube
     # AO
     ControlAOHatch:
         cmd: ao.ControlAOHatch.ControlAOHatch

--- a/kpf/linking_table.yml
+++ b/kpf/linking_table.yml
@@ -104,6 +104,8 @@ links:
     # FVCs
     FVCPower:
         cmd: fvc.FVCPower.FVCPower
+    PredictFVCParameters:
+        cmd: fvc.PredictFVCParameters.PredictFVCParameters
     TakeFVCContinuous:
         cmd: fvc.TakeFVCContinuous.TakeFVCContinuous
     TakeFVCExposure:

--- a/kpf/linking_table.yml
+++ b/kpf/linking_table.yml
@@ -6,8 +6,8 @@ links:
     # Analysis
     AnalyzeGridSearch:
         cmd: analysis.AnalyzeGridSearch.AnalyzeGridSearch
-    AnalyzeGuideCube:
-        cmd: analysis.AnalyzeGuideCube.AnalyzeGuideCube
+    AnalyzeTipTiltPerformance:
+        cmd: analysis.AnalyzeTipTiltPerformance.AnalyzeTipTiltPerformance
     Fit2DGridSearch:
         cmd: analysis.Fit2DGridSearch.Fit2DGridSearch
     # AO

--- a/kpf/linking_table.yml
+++ b/kpf/linking_table.yml
@@ -25,6 +25,8 @@ links:
     # Cal Bench
     CalLampPower:
         cmd: calbench.CalLampPower.CalLampPower
+    IsCalSourceEnabled:
+        cmd: calbench.IsCalSourceEnabled.IsCalSourceEnabled
     SetCalSource:
         cmd: calbench.SetCalSource.SetCalSource
     SetFlatFieldFiberPos:

--- a/kpf/linking_table.yml
+++ b/kpf/linking_table.yml
@@ -185,6 +185,10 @@ links:
     WaitForConfigureCalOB:
         cmd: scripts.WaitForConfigureCalOB.WaitForConfigureCalOB
     # Spectrograph
+    ResetGreenDetector:
+        cmd: spectrograph.ResetDetectors.ResetGreenDetector
+    ResetRedDetector:
+        cmd: spectrograph.ResetDetectors.ResetRedDetector
     ResetDetectors:
         cmd: spectrograph.ResetDetectors.ResetDetectors
     SetExptime:

--- a/kpf/linking_table.yml
+++ b/kpf/linking_table.yml
@@ -56,10 +56,14 @@ links:
     WaitForND2:
         cmd: calbench.WaitForND2.WaitForND2
     # ExpMeter
+    BuildMasterBias:
+        cmd: expmeter.BuildMasterBias.BuildMasterBias
     SetExpMeterExptime:
         cmd: expmeter.SetExpMeterExptime.SetExpMeterExptime
     PredictExpMeterParameters:
         cmd: expmeter.PredictExpMeterParameters.PredictExpMeterParameters
+    TakeExpMeterBiases:
+        cmd: expmeter.TakeExpMeterBiases.TakeExpMeterBiases
     # FIU
     ConfigureFIU:
         cmd: fiu.ConfigureFIU.ConfigureFIU

--- a/kpf/scripts/CleanupAfterCalibrations.py
+++ b/kpf/scripts/CleanupAfterCalibrations.py
@@ -13,7 +13,6 @@ from kpf.scripts import (register_script, obey_scriptrun, check_scriptstop,
                          add_script_log)
 from kpf.calbench.CalLampPower import CalLampPower
 from kpf.calbench.IsCalSourceEnabled import IsCalSourceEnabled
-from kpf.calbench.SetLFCtoStandbyHigh import SetLFCtoStandbyHigh
 from kpf.fiu.ConfigureFIU import ConfigureFIU
 from kpf.spectrograph.SetObject import SetObject
 from kpf.spectrograph.WaitForReady import WaitForReady
@@ -61,8 +60,6 @@ class CleanupAfterCalibrations(KPFTranslatorFunction):
                     if lamp in ['Th_daily', 'Th_gold', 'U_daily', 'U_gold',
                                 'BrdbandFiber', 'WideFlat']:
                         CalLampPower.execute({'lamp': lamp, 'power': 'off'})
-                    if lamp == 'LFCFiber':
-                        SetLFCtoStandbyHigh.execute({})
 
         log.info(f"Stowing FIU")
         ConfigureFIU.execute({'mode': 'Stowed'})

--- a/kpf/scripts/CleanupAfterCalibrations.py
+++ b/kpf/scripts/CleanupAfterCalibrations.py
@@ -56,11 +56,12 @@ class CleanupAfterCalibrations(KPFTranslatorFunction):
             sequence = OB.get('SEQ_Calibrations')
             lamps = set([x['CalSource'] for x in sequence if x['CalSource'] != 'Home'])
             for lamp in lamps:
-                if lamp in ['Th_daily', 'Th_gold', 'U_daily', 'U_gold',
-                            'BrdbandFiber', 'WideFlat']:
-                    CalLampPower.execute({'lamp': lamp, 'power': 'off'})
-                if lamp == 'LFCFiber':
-                    SetLFCtoStandbyHigh.execute({})
+                if IsCalSourceEnabled.execute({'CalSource': lamp}) == True:
+                    if lamp in ['Th_daily', 'Th_gold', 'U_daily', 'U_gold',
+                                'BrdbandFiber', 'WideFlat']:
+                        CalLampPower.execute({'lamp': lamp, 'power': 'off'})
+                    if lamp == 'LFCFiber':
+                        SetLFCtoStandbyHigh.execute({})
 
         log.info(f"Stowing FIU")
         ConfigureFIU.execute({'mode': 'Stowed'})

--- a/kpf/scripts/CleanupAfterCalibrations.py
+++ b/kpf/scripts/CleanupAfterCalibrations.py
@@ -12,6 +12,7 @@ from kpf import (log, KPFException, FailedPreCondition, FailedPostCondition,
 from kpf.scripts import (register_script, obey_scriptrun, check_scriptstop,
                          add_script_log)
 from kpf.calbench.CalLampPower import CalLampPower
+from kpf.calbench.IsCalSourceEnabled import IsCalSourceEnabled
 from kpf.calbench.SetLFCtoStandbyHigh import SetLFCtoStandbyHigh
 from kpf.fiu.ConfigureFIU import ConfigureFIU
 from kpf.spectrograph.SetObject import SetObject

--- a/kpf/scripts/ConfigureForAcquisition.py
+++ b/kpf/scripts/ConfigureForAcquisition.py
@@ -110,7 +110,7 @@ class ConfigureForAcquisition(KPFTranslatorFunction):
             if OB.get('GuideFPS', None) is not None:
                 SetGuiderFPS.execute(OB)
         elif guide_mode == 'auto':
-            guider_parameters = PredictGuiderParameters.execute({OB})
+            guider_parameters = PredictGuiderParameters.execute(OB)
             SetGuiderGain.execute(guider_parameters)
             SetGuiderFPS.execute(guider_parameters)
         else:

--- a/kpf/scripts/ConfigureForAcquisition.py
+++ b/kpf/scripts/ConfigureForAcquisition.py
@@ -14,7 +14,7 @@ from kpf.scripts import (register_script, obey_scriptrun, check_scriptstop,
                          add_script_log)
 from kpf.scripts.ExecuteSlewCal import ExecuteSlewCal
 from kpf.calbench.SetCalSource import SetCalSource
-from kpf.guider.PredictGuiderParameters import predict_guider_parameters
+from kpf.guider.PredictGuiderParameters import PredictGuiderParameters
 from kpf.guider.SetGuiderFPS import SetGuiderFPS
 from kpf.guider.SetGuiderGain import SetGuiderGain
 from kpf.fiu.InitializeTipTilt import InitializeTipTilt
@@ -110,7 +110,7 @@ class ConfigureForAcquisition(KPFTranslatorFunction):
             if OB.get('GuideFPS', None) is not None:
                 SetGuiderFPS.execute(OB)
         elif guide_mode == 'auto':
-            guider_parameters = predict_guider_parameters(OB.get('Jmag'))
+            guider_parameters = PredictGuiderParameters.execute({OB})
             SetGuiderGain.execute(guider_parameters)
             SetGuiderFPS.execute(guider_parameters)
         else:

--- a/kpf/scripts/ConfigureForCalibrations.py
+++ b/kpf/scripts/ConfigureForCalibrations.py
@@ -12,6 +12,7 @@ from kpf import (log, KPFException, FailedPreCondition, FailedPostCondition,
 from kpf.scripts import (register_script, obey_scriptrun, check_scriptstop,
                          add_script_log)
 from kpf.calbench.CalLampPower import CalLampPower
+from kpf.calbench.IsCalSourceEnabled import IsCalSourceEnabled
 from kpf.calbench.SetLFCtoAstroComb import SetLFCtoAstroComb
 from kpf.fiu.ConfigureFIU import ConfigureFIU
 from kpf.spectrograph.SetTriggeredDetectors import SetTriggeredDetectors
@@ -53,11 +54,12 @@ class ConfigureForCalibrations(KPFTranslatorFunction):
         sequence = OB.get('SEQ_Calibrations')
         lamps = set([x['CalSource'] for x in sequence if x['CalSource'] != 'Home'])
         for lamp in lamps:
-            if lamp in ['Th_daily', 'Th_gold', 'U_daily', 'U_gold',
-                        'BrdbandFiber', 'WideFlat']:
-                CalLampPower.execute({'lamp': lamp, 'power': 'on'})
-            if lamp == 'LFCFiber':
-                SetLFCtoAstroComb.execute({})
+            if IsCalSourceEnabled.execute(args) == True:
+                if lamp in ['Th_daily', 'Th_gold', 'U_daily', 'U_gold',
+                            'BrdbandFiber', 'WideFlat']:
+                    CalLampPower.execute({'lamp': lamp, 'power': 'on'})
+                if lamp == 'LFCFiber':
+                    SetLFCtoAstroComb.execute({})
 
         log.debug(f"Ensuring back illumination LEDs are off")
         CalLampPower.execute({'lamp': 'ExpMeterLED', 'power': 'off'})

--- a/kpf/scripts/ConfigureForCalibrations.py
+++ b/kpf/scripts/ConfigureForCalibrations.py
@@ -54,7 +54,7 @@ class ConfigureForCalibrations(KPFTranslatorFunction):
         sequence = OB.get('SEQ_Calibrations')
         lamps = set([x['CalSource'] for x in sequence if x['CalSource'] != 'Home'])
         for lamp in lamps:
-            if IsCalSourceEnabled.execute(args) == True:
+            if IsCalSourceEnabled.execute(OB) == True:
                 if lamp in ['Th_daily', 'Th_gold', 'U_daily', 'U_gold',
                             'BrdbandFiber', 'WideFlat']:
                     CalLampPower.execute({'lamp': lamp, 'power': 'on'})

--- a/kpf/scripts/ConfigureForCalibrations.py
+++ b/kpf/scripts/ConfigureForCalibrations.py
@@ -13,7 +13,6 @@ from kpf.scripts import (register_script, obey_scriptrun, check_scriptstop,
                          add_script_log)
 from kpf.calbench.CalLampPower import CalLampPower
 from kpf.calbench.IsCalSourceEnabled import IsCalSourceEnabled
-from kpf.calbench.SetLFCtoAstroComb import SetLFCtoAstroComb
 from kpf.fiu.ConfigureFIU import ConfigureFIU
 from kpf.spectrograph.SetTriggeredDetectors import SetTriggeredDetectors
 from kpf.spectrograph.WaitForReady import WaitForReady
@@ -58,11 +57,6 @@ class ConfigureForCalibrations(KPFTranslatorFunction):
                 if lamp in ['Th_daily', 'Th_gold', 'U_daily', 'U_gold',
                             'BrdbandFiber', 'WideFlat']:
                     CalLampPower.execute({'lamp': lamp, 'power': 'on'})
-                if lamp == 'LFCFiber':
-                    try:
-                        SetLFCtoAstroComb.execute({})
-                    except:
-                        log.error('Failed to set LFC to AstroComb')
 
         log.debug(f"Ensuring back illumination LEDs are off")
         CalLampPower.execute({'lamp': 'ExpMeterLED', 'power': 'off'})

--- a/kpf/scripts/ConfigureForCalibrations.py
+++ b/kpf/scripts/ConfigureForCalibrations.py
@@ -54,7 +54,7 @@ class ConfigureForCalibrations(KPFTranslatorFunction):
         sequence = OB.get('SEQ_Calibrations')
         lamps = set([x['CalSource'] for x in sequence if x['CalSource'] != 'Home'])
         for lamp in lamps:
-            if IsCalSourceEnabled.execute(OB) == True:
+            if IsCalSourceEnabled.execute({'CalSource': lamp}) == True:
                 if lamp in ['Th_daily', 'Th_gold', 'U_daily', 'U_gold',
                             'BrdbandFiber', 'WideFlat']:
                     CalLampPower.execute({'lamp': lamp, 'power': 'on'})

--- a/kpf/scripts/ConfigureForCalibrations.py
+++ b/kpf/scripts/ConfigureForCalibrations.py
@@ -59,7 +59,10 @@ class ConfigureForCalibrations(KPFTranslatorFunction):
                             'BrdbandFiber', 'WideFlat']:
                     CalLampPower.execute({'lamp': lamp, 'power': 'on'})
                 if lamp == 'LFCFiber':
-                    SetLFCtoAstroComb.execute({})
+                    try:
+                        SetLFCtoAstroComb.execute({})
+                    except FailedPostCondition as e:
+                        log.error('Failed to set LFC to AstroComb')
 
         log.debug(f"Ensuring back illumination LEDs are off")
         CalLampPower.execute({'lamp': 'ExpMeterLED', 'power': 'off'})

--- a/kpf/scripts/ConfigureForCalibrations.py
+++ b/kpf/scripts/ConfigureForCalibrations.py
@@ -61,7 +61,7 @@ class ConfigureForCalibrations(KPFTranslatorFunction):
                 if lamp == 'LFCFiber':
                     try:
                         SetLFCtoAstroComb.execute({})
-                    except FailedPostCondition as e:
+                    except:
                         log.error('Failed to set LFC to AstroComb')
 
         log.debug(f"Ensuring back illumination LEDs are off")

--- a/kpf/scripts/ConfigureForScience.py
+++ b/kpf/scripts/ConfigureForScience.py
@@ -17,6 +17,7 @@ from kpf.calbench.SetCalSource import SetCalSource
 from kpf.fiu.ConfigureFIU import ConfigureFIU
 from kpf.fiu.SetCurrentBase import SetCurrentBase
 from kpf.fiu.StartTipTilt import StartTipTilt
+from kpf.fiu.WaitForTipTilt import WaitForTipTilt
 from kpf.spectrograph.SetSourceSelectShutters import SetSourceSelectShutters
 from kpf.spectrograph.SetTriggeredDetectors import SetTriggeredDetectors
 from kpf.spectrograph.WaitForReady import WaitForReady
@@ -62,7 +63,6 @@ class ConfigureForScience(KPFTranslatorFunction):
             log.info(f"Starting tip tilt loops")
             SetCurrentBase.execute(OB)
             StartTipTilt.execute({})
-            tick = datetime.now()
         elif OB['GuideMode'] in ['off', 'telescope']:
             log.info('GuideMode in OB is "off", not starting tip tilt loops')
 
@@ -94,13 +94,7 @@ class ConfigureForScience(KPFTranslatorFunction):
 
         # Make sure tip tilt loops have had time to close
         if OB['GuideMode'] in ['manual', 'auto']:
-            tock = datetime.now()
-            time_passed = (tock - tick).total_seconds()
-            tt_close_time = cfg.getfloat('times', 'tip_tilt_close_time', fallback=3)
-            sleep_time = tt_close_time - time_passed
-            if sleep_time > 0:
-                log.info(f"Sleeping {sleep_time:.1f} seconds to allow loops to close")
-                time.sleep(sleep_time)
+            WaitForTipTilt.execute({})
 
     @classmethod
     def post_condition(cls, OB, logger, cfg):

--- a/kpf/scripts/ConfigureForScience.py
+++ b/kpf/scripts/ConfigureForScience.py
@@ -26,8 +26,10 @@ from kpf.spectrograph.WaitForReady import WaitForReady
 class ConfigureForScience(KPFTranslatorFunction):
     '''Script which configures the instrument for Science observations.
 
+    - If needed, start tip tilt loops
     - Sets octagon / simulcal source
     - Sets source select shutters
+    - Set triggered detectors
 
     This must have arguments as input, either from a file using the `-f` command
     line tool, or passed in from the execution engine.

--- a/kpf/scripts/ExecuteCal.py
+++ b/kpf/scripts/ExecuteCal.py
@@ -103,9 +103,9 @@ class ExecuteCal(KPFTranslatorFunction):
                 TakeIntensityReading.execute({})
         ## Setup SoCal
         elif calsource in ['SoCal-CalFib']:
-            raise NotImplementedError()
-            # OCTAGON=SoCal-CalFib
-            # SSS_SoCalCal open, SSS_CalSciSky open
+            SetCalSource.execute({'CalSource': calsource, 'wait': False})
+            # Open SoCalCal Shutter
+            args['SSS_SoCalCal'] = True
         elif calsource in ['SoCal-SciSky']:
             # Set octagon to simulcal source
             simulcalsource = kpfconfig['SIMULCALSOURCE'].read()
@@ -153,6 +153,8 @@ class ExecuteCal(KPFTranslatorFunction):
         # No need to specify SSS_CalSciSky in OB/calibration
         if calsource in ['SoCal-SciSky']:
             args['SSS_CalSciSky'] = False
+        elif calsource in ['SoCal-CalFib']:
+            args['SSS_CalSciSky'] = True
         else:
             args['SSS_CalSciSky'] = args['SSS_Science'] or args['SSS_Sky']
         log.debug(f"Automatically setting SSS_CalSciSky: {args['SSS_CalSciSky']}")

--- a/kpf/scripts/ExecuteCal.py
+++ b/kpf/scripts/ExecuteCal.py
@@ -95,14 +95,6 @@ class ExecuteCal(KPFTranslatorFunction):
             WaitForCalSource.execute({'CalSource': 'Home'})
             WaitForFlatFieldFiberPos.execute(args)
             WaitForConfigureFIU.execute({'mode': 'Calibration'})
-        ## If we're using the LFC, set it to AstroComb
-        ## If that fails, skip this calibration
-        elif calsource == 'LFCFiber':
-            try:
-                SetLFCtoAstroComb.execute({})
-            except:
-                log.error('Failed to set LFC to AstroComb')
-                return
         ## Setup Octagon Lamps and LFCFiber
         elif calsource in ['BrdbandFiber', 'U_gold', 'U_daily', 'Th_daily',
                            'Th_gold', 'LFCFiber', 'EtalonFiber']:
@@ -117,10 +109,14 @@ class ExecuteCal(KPFTranslatorFunction):
             WaitForCalSource.execute(args)
             WaitForConfigureFIU.execute({'mode': 'Calibration'})
             # Take intensity monitor reading
-            if calsource != 'LFCFiber' and args.get('nointensemon', False) == False:
-                WaitForLampWarm.execute(args)
-                TakeIntensityReading.execute({})
             if calsource == 'LFCFiber':
+                ## If we're using the LFC, set it to AstroComb
+                ## If that fails, skip this calibration
+                try:
+                    SetLFCtoAstroComb.execute({})
+                except:
+                    log.error('Failed to set LFC to AstroComb')
+                    return
                 # Check menlo heatbeat
                 heartbeat = ktl.cache('kpfmon', 'HB_MENLOSTA')
                 heartbeat_ok = heartbeat.waitFor('== "OK"', timeout=3)
@@ -133,6 +129,9 @@ class ExecuteCal(KPFTranslatorFunction):
                 if LFCready_ok is not True:
                     log.error('LFCREADYSTA not Ok. Skipping LFC.')
                     return
+            if calsource != 'LFCFiber' and args.get('nointensemon', False) == False:
+                WaitForLampWarm.execute(args)
+                TakeIntensityReading.execute({})
         ## Setup SoCal
         elif calsource in ['SoCal-CalFib']:
             SetCalSource.execute({'CalSource': calsource, 'wait': False})

--- a/kpf/scripts/ExecuteCal.py
+++ b/kpf/scripts/ExecuteCal.py
@@ -151,10 +151,10 @@ class ExecuteCal(KPFTranslatorFunction):
         SetExpTime.execute(args)
         log.info(f"Setting source select shutters")
         # No need to specify SSS_CalSciSky in OB/calibration
-        if calsource in ['SoCal-SciSky'] == False:
-            args['SSS_CalSciSky'] = args['SSS_Science'] or args['SSS_Sky']
-        else:
+        if calsource in ['SoCal-SciSky']:
             args['SSS_CalSciSky'] = False
+        else:
+            args['SSS_CalSciSky'] = args['SSS_Science'] or args['SSS_Sky']
         log.debug(f"Automatically setting SSS_CalSciSky: {args['SSS_CalSciSky']}")
         SetSourceSelectShutters.execute(args)
 

--- a/kpf/scripts/ExecuteCal.py
+++ b/kpf/scripts/ExecuteCal.py
@@ -112,7 +112,7 @@ class ExecuteCal(KPFTranslatorFunction):
                 TakeIntensityReading.execute({})
             if calsource == 'LFCFiber':
                 # Check menlo heatbeat
-                heartbeat = ktl.cache('kpfmon', 'NE_HB_MENLO')
+                heartbeat = ktl.cache('kpfmon', 'HB_MENLOSTA')
                 heartbeat_ok = heartbeat.waitFor('== "OK"', timeout=3)
                 if heartbeat_ok is not True:
                     log.error('Menlo heartbeat not Ok. Skipping LFC.')

--- a/kpf/scripts/ExecuteCal.py
+++ b/kpf/scripts/ExecuteCal.py
@@ -59,6 +59,11 @@ class ExecuteCal(KPFTranslatorFunction):
 
     @classmethod
     def perform(cls, args, logger, cfg):
+        log.info('-------------------------')
+        log.info(f"Running {cls.__name__}")
+        for key in args:
+            log.debug(f"  {key}: {args[key]}")
+        log.info('-------------------------')
         exposestatus = ktl.cache('kpfexpose', 'EXPOSE')
         kpfconfig = ktl.cache('kpfconfig')
         runagitator = kpfconfig['USEAGITATOR'].read(binary=True)

--- a/kpf/scripts/ExecuteCal.py
+++ b/kpf/scripts/ExecuteCal.py
@@ -11,6 +11,7 @@ from kpf import (log, KPFException, FailedPreCondition, FailedPostCondition,
 from kpf.scripts import (register_script, obey_scriptrun, check_scriptstop,
                          add_script_log)
 from kpf.calbench.CalLampPower import CalLampPower
+from kpf.calbench.IsCalSourceEnabled import IsCalSourceEnabled
 from kpf.calbench.SetCalSource import SetCalSource
 from kpf.calbench.SetFlatFieldFiberPos import SetFlatFieldFiberPos
 from kpf.calbench.SetND1 import SetND1
@@ -67,6 +68,9 @@ class ExecuteCal(KPFTranslatorFunction):
                              fallback=2)
 
         calsource = args.get('CalSource')
+        # Skip this lamp if it is not enabled
+        if IsCalSourceEnabled.execute(args) == False:
+            return
         nd1 = args.get('CalND1')
         nd2 = args.get('CalND2')
         ## ----------------------------------------------------------------
@@ -123,9 +127,7 @@ class ExecuteCal(KPFTranslatorFunction):
             args['SSS_SoCalSci'] = True
         # WTF!?
         else:
-            msg = f"CalSource {calsource} not recognized"
-            log.error(msg)
-            raise Exception(msg)
+            raise KPFException(f"CalSource {calsource} not recognized")
 
         ## ----------------------------------------------------------------
         ## Configure exposure meter

--- a/kpf/scripts/ExecuteCal.py
+++ b/kpf/scripts/ExecuteCal.py
@@ -110,6 +110,19 @@ class ExecuteCal(KPFTranslatorFunction):
             if calsource != 'LFCFiber' and args.get('nointensemon', False) == False:
                 WaitForLampWarm.execute(args)
                 TakeIntensityReading.execute({})
+            if calsource == 'LFCFiber':
+                # Check menlo heatbeat
+                heartbeat = ktl.cache('kpfmon', 'NE_HB_MENLO')
+                heartbeat_ok = heartbeat.waitFor('== "OK"', timeout=3)
+                if heartbeat_ok is not True:
+                    log.error('Menlo heartbeat not Ok. Skipping LFC.')
+                    return
+                # Check LFCREADYSTA
+                LFCready = ktl.cache('kpfmon', 'LFCREADYSTA')
+                LFCready_ok = LFCready.waitFor('== "OK"', timeout=3)
+                if LFCready_ok is not True:
+                    log.error('LFCREADYSTA not Ok. Skipping LFC.')
+                    return
         ## Setup SoCal
         elif calsource in ['SoCal-CalFib']:
             SetCalSource.execute({'CalSource': calsource, 'wait': False})

--- a/kpf/scripts/ExecuteCal.py
+++ b/kpf/scripts/ExecuteCal.py
@@ -98,7 +98,7 @@ class ExecuteCal(KPFTranslatorFunction):
             WaitForCalSource.execute(args)
             WaitForConfigureFIU.execute({'mode': 'Calibration'})
             # Take intensity monitor reading
-            if calsource != 'LFCFiber':
+            if calsource != 'LFCFiber' and args.get('nointensemon', False) == False:
                 WaitForLampWarm.execute(args)
                 TakeIntensityReading.execute({})
         ## Setup SoCal
@@ -190,3 +190,10 @@ class ExecuteCal(KPFTranslatorFunction):
     @classmethod
     def post_condition(cls, args, logger, cfg):
         pass
+
+    @classmethod
+    def add_cmdline_args(cls, parser, cfg=None):
+        parser.add_argument('--nointensemon', dest="nointensemon",
+                            default=False, action="store_true",
+                            help='Skip the intensity monitor measurement?')
+        return super().add_cmdline_args(parser, cfg)

--- a/kpf/scripts/ExecuteSci.py
+++ b/kpf/scripts/ExecuteSci.py
@@ -23,7 +23,7 @@ from kpf.calbench.SetND1 import SetND1
 from kpf.calbench.SetND2 import SetND2
 from kpf.calbench.WaitForND1 import WaitForND1
 from kpf.calbench.WaitForND2 import WaitForND2
-from kpf.expmeter.PredictExpMeterParameters import predict_expmeter_parameters
+from kpf.expmeter.PredictExpMeterParameters import PredictExpMeterParameters
 from kpf.expmeter.SetExpMeterExpTime import SetExpMeterExpTime
 
 
@@ -64,7 +64,7 @@ class ExecuteSci(KPFTranslatorFunction):
             log.warning(f"ExpMeterMode {EM_mode} is not available")
 
         if args.get('AutoExpMeter', False) in [True, 'True']:
-            em_params = predict_expmeter_parameters(args.get('Gmag'))
+            em_params = PredictExpMeterParameters.execute(args)
             EM_ExpTime = em_params.get('ExpMeterExpTime', None)
             log.debug(f'Automatically setting EM ExpTime')
             args['ExpMeterExpTime'] = EM_ExpTime

--- a/kpf/scripts/GridSearch.py
+++ b/kpf/scripts/GridSearch.py
@@ -365,6 +365,7 @@ class GridSearch(KPFTranslatorFunction):
 
         if grid == 'TipTilt':
             SetTipTiltTargetPixel.execute({'x': xpix0, 'y': ypix0})
+            StopTipTilt.execute({})
         elif grid == 'SciADC':
             kpffiu['ADC1NAM'].write('Null')
             kpffiu['ADC2NAM'].write('Null')

--- a/kpf/scripts/Run2DGridSearch.py
+++ b/kpf/scripts/Run2DGridSearch.py
@@ -33,6 +33,7 @@ class Run2DGridSearch(KPFTranslatorFunction):
     @classmethod
     def perform(cls, OB, logger, cfg):
         Gmag = args.get('Gmag')
+        additional_text = args.get('comment', '')
         em_parameters = PredictExpMeterParameters.execute({'Gmag': Gmag})
         fvc_parameters = PredictFVCParameters.execute({'Gmag': Gmag})
         dcs = ktl.cache('dcs')
@@ -54,13 +55,13 @@ class Run2DGridSearch(KPFTranslatorFunction):
                 'FVCs': 'SCI,CAHK',
                 }
         args.update(fvc_parameters)
-        x_args = {'comment': f'1D in X {targname}',
+        x_args = {'comment': f'1D in X {targname}: {additional_text}',
                   'nx': 15,
                   'ny': 1,
                   }
         args.update(x_args)
         GridSearch.execute(args)
-        y_args = {'comment': f'1D in Y {targname}',
+        y_args = {'comment': f'1D in Y {targname}: {additional_text}',
                   'nx': 1,
                   'ny': 15,
                   }
@@ -75,4 +76,7 @@ class Run2DGridSearch(KPFTranslatorFunction):
     def add_cmdline_args(cls, parser, cfg=None):
         parser.add_argument('Gmag', type=float,
                             help="The G magnitude of the target")
+        parser.add_argument("--comment", dest="comment", type=str,
+            default='',
+            help="Additional comment text")
         return super().add_cmdline_args(parser, cfg)

--- a/kpf/scripts/Run2DGridSearch.py
+++ b/kpf/scripts/Run2DGridSearch.py
@@ -1,4 +1,4 @@
-
+import ktl
 
 from kpf.KPFTranslatorFunction import KPFTranslatorFunction
 from kpf import (log, KPFException, FailedPreCondition, FailedPostCondition,
@@ -31,7 +31,7 @@ class Run2DGridSearch(KPFTranslatorFunction):
         pass
 
     @classmethod
-    def perform(cls, OB, logger, cfg):
+    def perform(cls, args, logger, cfg):
         Gmag = args.get('Gmag')
         additional_text = args.get('comment', '')
         em_parameters = PredictExpMeterParameters.execute({'Gmag': Gmag})

--- a/kpf/scripts/Run2DGridSearch.py
+++ b/kpf/scripts/Run2DGridSearch.py
@@ -1,0 +1,78 @@
+
+
+from kpf.KPFTranslatorFunction import KPFTranslatorFunction
+from kpf import (log, KPFException, FailedPreCondition, FailedPostCondition,
+                 FailedToReachDestination, check_input)
+from kpf.scripts import (register_script, obey_scriptrun, check_scriptstop,
+                         add_script_log)
+from kpf.scripts.GridSearch import GridSearch
+from kpf.fvc.PredictFVCParameters import PredictFVCParameters
+from kpf.expmeter.PredictExpMeterParameters import PredictExpMeterParameters
+
+
+##-------------------------------------------------------------------------
+## Run2DGridSearch
+##-------------------------------------------------------------------------
+class Run2DGridSearch(KPFTranslatorFunction):
+    '''Executes an engineering grid search OB.
+
+    This must have arguments as input, either from a file using the `-f` command
+    line tool, or passed in from the execution engine.
+
+    ARGS:
+    =====
+    None
+    '''
+    abortable = True
+
+    @classmethod
+    @obey_scriptrun
+    def pre_condition(cls, OB, logger, cfg):
+        pass
+
+    @classmethod
+    def perform(cls, OB, logger, cfg):
+        Gmag = args.get('Gmag')
+        em_parameters = PredictExpMeterParameters.execute({'Gmag': Gmag})
+        fvc_parameters = PredictFVCParameters.execute({'Gmag': Gmag})
+        dcs = ktl.cache('dcs')
+        targname = dcs['TARGNAME'].read()
+        args = {'Template_Name': 'kpf_eng_grid', 'Template_Version': 0.4,
+                'Grid': 'TipTilt',
+                'dx': 2,
+                'dy': 2,
+                'TimeOnPosition': 15,
+                'TriggerCaHK': False,
+                'TriggerGreen': False,
+                'TriggerRed': False,
+                'TriggerExpMeter': True,
+                'UseCRED2': True,
+                'SSS_Science': True,
+                'SSS_Sky': True,
+                'SSS_CalSciSky': False,
+                'ExpMeter_exptime': em_parameters['ExpMeterExpTime'],
+                'FVCs': 'SCI,CAHK',
+                }
+        args.update(fvc_parameters)
+        x_args = {'comment': f'1D in X {targname}',
+                  'nx': 15,
+                  'ny': 1,
+                  }
+        args.update(x_args)
+        GridSearch.execute(args)
+        y_args = {'comment': f'1D in Y {targname}',
+                  'nx': 1,
+                  'ny': 15,
+                  }
+        args.update(y_args)
+        GridSearch.execute(args)
+
+    @classmethod
+    def post_condition(cls, args, logger, cfg):
+        pass
+
+    @classmethod
+    def add_cmdline_args(cls, parser, cfg=None):
+        parser.add_argument('Gmag', type=float,
+                            help="The G magnitude of the target")
+        return super().add_cmdline_args(parser, cfg)

--- a/kpf/scripts/RunCalOB.py
+++ b/kpf/scripts/RunCalOB.py
@@ -163,4 +163,7 @@ class RunCalOB(KPFTranslatorFunction):
         parser.add_argument('--leave_lamps_on', dest="leave_lamps_on",
                             default=False, action="store_true",
                             help='Leave the lamps on after cleanup phase?')
+        parser.add_argument('--nointensemon', dest="nointensemon",
+                            default=False, action="store_true",
+                            help='Skip the intensity monitor measurement?')
         return super().add_cmdline_args(parser, cfg)

--- a/kpf/scripts/RunCalOB.py
+++ b/kpf/scripts/RunCalOB.py
@@ -69,15 +69,17 @@ class RunCalOB(KPFTranslatorFunction):
             log.error('Running CleanupAfterCalibrations and exiting')
             CleanupAfterCalibrations.execute(OB)
             # Email error to kpf_info
-            traceback_text = traceback.format_exc()
             try:
+                msg = [f'{type(e)}',
+                       f'{traceback.format_exc()}',
+                       '',
+                       f'{OB}']
                 SendEmail.execute({'Subject': 'ConfigureForCalibrations Failed',
-                                   'Message': f'{type(e)}: {traceback_text}'})
+                                   'Message': '\n'.join(msg)})
             except Exception as email_err:
                 log.error(f'Sending email failed')
                 log.error(email_err)
-
-            raise(e)
+            raise e
 
         check_script_running()
         set_script_keywords(Path(__file__).name, os.getpid())
@@ -104,16 +106,19 @@ class RunCalOB(KPFTranslatorFunction):
             log.error(e)
             clear_script_keywords()
             # Email error to kpf_info
-            traceback_text = traceback.format_exc()
             try:
+                msg = [f'{type(e)}',
+                       f'{traceback.format_exc()}',
+                       '',
+                       f'{OB}']
                 SendEmail.execute({'Subject': 'ExecuteDarks Failed',
-                                   'Message': f'{type(e)}: {traceback_text}'})
+                                   'Message': '\n'.join(msg)})
             except Exception as email_err:
                 log.error(f'Sending email failed')
                 log.error(email_err)
             # Cleanup
             CleanupAfterCalibrations.execute(OB)
-            raise(e)
+            raise e
 
         # Execute the Cal Sequence
         try:
@@ -132,14 +137,18 @@ class RunCalOB(KPFTranslatorFunction):
             # Email error to kpf_info
             traceback_text = traceback.format_exc()
             try:
+                msg = [f'{type(e)}',
+                       f'{traceback.format_exc()}',
+                       '',
+                       f'{OB}']
                 SendEmail.execute({'Subject': 'ExecuteCals Failed',
-                                   'Message': f'{type(e)}: {traceback_text}'})
+                                   'Message': '\n'.join(msg)})
             except Exception as email_err:
                 log.error(f'Sending email failed')
                 log.error(email_err)
             # Cleanup
             CleanupAfterCalibrations.execute(OB)
-            raise(e)
+            raise e
 
         clear_script_keywords()
 
@@ -152,12 +161,16 @@ class RunCalOB(KPFTranslatorFunction):
             # Email error to kpf_info
             traceback_text = traceback.format_exc()
             try:
+                msg = [f'{type(e)}',
+                       f'{traceback.format_exc()}',
+                       '',
+                       f'{OB}']
                 SendEmail.execute({'Subject': 'CleanupAfterCalibrations Failed',
-                                   'Message': f'{type(e)}: {traceback_text}'})
+                                   'Message': '\n'.join(msg)})
             except Exception as email_err:
                 log.error(f'Sending email failed')
                 log.error(email_err)
-            raise(e)
+            raise e
 
     @classmethod
     def post_condition(cls, OB, logger, cfg):

--- a/kpf/scripts/RunCalOB.py
+++ b/kpf/scripts/RunCalOB.py
@@ -1,6 +1,7 @@
 from time import sleep
 from pathlib import Path
 import os
+import traceback
 
 import ktl
 
@@ -68,9 +69,10 @@ class RunCalOB(KPFTranslatorFunction):
             log.error('Running CleanupAfterCalibrations and exiting')
             CleanupAfterCalibrations.execute(OB)
             # Email error to kpf_info
+            traceback_text = traceback.format_exc()
             try:
                 SendEmail.execute({'Subject': 'ConfigureForCalibrations Failed',
-                                   'Message': f'{type(e)}: {e}'})
+                                   'Message': f'{type(e)}: {traceback_text}'})
             except Exception as email_err:
                 log.error(f'Sending email failed')
                 log.error(email_err)
@@ -102,9 +104,10 @@ class RunCalOB(KPFTranslatorFunction):
             log.error(e)
             clear_script_keywords()
             # Email error to kpf_info
+            traceback_text = traceback.format_exc()
             try:
                 SendEmail.execute({'Subject': 'ExecuteDarks Failed',
-                                   'Message': f'{type(e)}: {e}'})
+                                   'Message': f'{type(e)}: {traceback_text}'})
             except Exception as email_err:
                 log.error(f'Sending email failed')
                 log.error(email_err)
@@ -127,9 +130,10 @@ class RunCalOB(KPFTranslatorFunction):
             log.error(e)
             clear_script_keywords()
             # Email error to kpf_info
+            traceback_text = traceback.format_exc()
             try:
                 SendEmail.execute({'Subject': 'ExecuteCals Failed',
-                                   'Message': f'{type(e)}: {e}'})
+                                   'Message': f'{type(e)}: {traceback_text}'})
             except Exception as email_err:
                 log.error(f'Sending email failed')
                 log.error(email_err)
@@ -146,9 +150,10 @@ class RunCalOB(KPFTranslatorFunction):
             log.error("CleanupAfterCalibrations failed:")
             log.error(e)
             # Email error to kpf_info
+            traceback_text = traceback.format_exc()
             try:
                 SendEmail.execute({'Subject': 'CleanupAfterCalibrations Failed',
-                                   'Message': f'{type(e)}: {e}'})
+                                   'Message': f'{type(e)}: {traceback_text}'})
             except Exception as email_err:
                 log.error(f'Sending email failed')
                 log.error(email_err)

--- a/kpf/scripts/RunCalOB.py
+++ b/kpf/scripts/RunCalOB.py
@@ -7,7 +7,7 @@ import ktl
 
 from kpf.KPFTranslatorFunction import KPFTranslatorFunction
 from kpf import (log, KPFException, FailedPreCondition, FailedPostCondition,
-                 FailedToReachDestination, check_input)
+                 FailedToReachDestination, check_input, ScriptStopTriggered)
 from kpf.scripts import (set_script_keywords, clear_script_keywords,
                          add_script_log, check_script_running)
 from kpf.scripts.ConfigureForCalibrations import ConfigureForCalibrations
@@ -66,19 +66,22 @@ class RunCalOB(KPFTranslatorFunction):
         except Exception as e:
             log.error('ConfigureForCalibrations Failed')
             log.error(e)
+            traceback_text = traceback.format_exc()
+            log.error(traceback_text)
+            # Email error to kpf_info
+            if not isinstance(e, ScriptStopTriggered):
+                try:
+                    msg = [f'{type(e)}',
+                           f'{traceback_text}',
+                           '',
+                           f'{OB}']
+                    SendEmail.execute({'Subject': 'ConfigureForCalibrations Failed',
+                                       'Message': '\n'.join(msg)})
+                except Exception as email_err:
+                    log.error(f'Sending email failed')
+                    log.error(email_err)
             log.error('Running CleanupAfterCalibrations and exiting')
             CleanupAfterCalibrations.execute(OB)
-            # Email error to kpf_info
-            try:
-                msg = [f'{type(e)}',
-                       f'{traceback.format_exc()}',
-                       '',
-                       f'{OB}']
-                SendEmail.execute({'Subject': 'ConfigureForCalibrations Failed',
-                                   'Message': '\n'.join(msg)})
-            except Exception as email_err:
-                log.error(f'Sending email failed')
-                log.error(email_err)
             raise e
 
         check_script_running()
@@ -104,19 +107,23 @@ class RunCalOB(KPFTranslatorFunction):
         except Exception as e:
             log.error("ExecuteDarks failed:")
             log.error(e)
+            traceback_text = traceback.format_exc()
+            log.error(traceback_text)
             clear_script_keywords()
             # Email error to kpf_info
-            try:
-                msg = [f'{type(e)}',
-                       f'{traceback.format_exc()}',
-                       '',
-                       f'{OB}']
-                SendEmail.execute({'Subject': 'ExecuteDarks Failed',
-                                   'Message': '\n'.join(msg)})
-            except Exception as email_err:
-                log.error(f'Sending email failed')
-                log.error(email_err)
+            if not isinstance(e, ScriptStopTriggered):
+                try:
+                    msg = [f'{type(e)}',
+                           f'{traceback_text}',
+                           '',
+                           f'{OB}']
+                    SendEmail.execute({'Subject': 'ExecuteDarks Failed',
+                                       'Message': '\n'.join(msg)})
+                except Exception as email_err:
+                    log.error(f'Sending email failed')
+                    log.error(email_err)
             # Cleanup
+            log.error('Running CleanupAfterCalibrations and exiting')
             CleanupAfterCalibrations.execute(OB)
             raise e
 
@@ -133,20 +140,23 @@ class RunCalOB(KPFTranslatorFunction):
         except Exception as e:
             log.error("ExecuteCal failed:")
             log.error(e)
+            traceback_text = traceback.format_exc()
+            log.error(traceback_text)
             clear_script_keywords()
             # Email error to kpf_info
-            traceback_text = traceback.format_exc()
-            try:
-                msg = [f'{type(e)}',
-                       f'{traceback.format_exc()}',
-                       '',
-                       f'{OB}']
-                SendEmail.execute({'Subject': 'ExecuteCals Failed',
-                                   'Message': '\n'.join(msg)})
-            except Exception as email_err:
-                log.error(f'Sending email failed')
-                log.error(email_err)
+            if not isinstance(e, ScriptStopTriggered):
+                try:
+                    msg = [f'{type(e)}',
+                           f'{traceback.format_exc()}',
+                           '',
+                           f'{OB}']
+                    SendEmail.execute({'Subject': 'ExecuteCals Failed',
+                                       'Message': '\n'.join(msg)})
+                except Exception as email_err:
+                    log.error(f'Sending email failed')
+                    log.error(email_err)
             # Cleanup
+            log.error('Running CleanupAfterCalibrations and exiting')
             CleanupAfterCalibrations.execute(OB)
             raise e
 
@@ -158,18 +168,20 @@ class RunCalOB(KPFTranslatorFunction):
         except Exception as e:
             log.error("CleanupAfterCalibrations failed:")
             log.error(e)
-            # Email error to kpf_info
             traceback_text = traceback.format_exc()
-            try:
-                msg = [f'{type(e)}',
-                       f'{traceback.format_exc()}',
-                       '',
-                       f'{OB}']
-                SendEmail.execute({'Subject': 'CleanupAfterCalibrations Failed',
-                                   'Message': '\n'.join(msg)})
-            except Exception as email_err:
-                log.error(f'Sending email failed')
-                log.error(email_err)
+            log.error(traceback_text)
+            # Email error to kpf_info
+            if not isinstance(e, ScriptStopTriggered):
+                try:
+                    msg = [f'{type(e)}',
+                           f'{traceback_text}',
+                           '',
+                           f'{OB}']
+                    SendEmail.execute({'Subject': 'CleanupAfterCalibrations Failed',
+                                       'Message': '\n'.join(msg)})
+                except Exception as email_err:
+                    log.error(f'Sending email failed')
+                    log.error(email_err)
             raise e
 
     @classmethod

--- a/kpf/scripts/StartOfNight.py
+++ b/kpf/scripts/StartOfNight.py
@@ -112,7 +112,19 @@ class StartOfNight(KPFTranslatorFunction):
         SetOutdirs.execute({})
         # Set progname and observer
         SetObserverFromSchedule.execute({})
-
+        # Summarize Detector Disabled States
+        cahk_enabled = kpfconfig['CA_HK_ENABLED'].read(binary=True)
+        if cahk_enabled is False:
+            log.warning(f"The CA_HK detector is disabled tonight")
+        green_enabled = kpfconfig['GREEN_ENABLED'].read(binary=True)
+        if green_enabled is False:
+            log.warning(f"The Green detector is disabled tonight")
+        red_enabled = kpfconfig['RED_ENABLED'].read(binary=True)
+        if red_enabled is False:
+            log.warning(f"The Red detector is disabled tonight")
+        expmeter_enabled = kpfconfig['EXPMETER_ENABLED'].read(binary=True)
+        if expmeter_enabled is False:
+            log.warning(f"The ExpMeter detector is disabled tonight")
 
     @classmethod
     def post_condition(cls, args, logger, cfg):

--- a/kpf/scripts/StartOfNight.py
+++ b/kpf/scripts/StartOfNight.py
@@ -72,6 +72,7 @@ class StartOfNight(KPFTranslatorFunction):
         # Power on Simulcal lamp
         kpfconfig = ktl.cache('kpfconfig')
         calsource = kpfconfig['SIMULCALSOURCE'].read()
+        log.info(f"Simultaneous calibration sournce for tonight is {calsource}")
         if calsource in ['U_gold', 'U_daily', 'Th_daily', 'Th_gold']:
             CalLampPower.execute({'lamp': calsource, 'power': 'on'})
 

--- a/kpf/scripts/__init__.py
+++ b/kpf/scripts/__init__.py
@@ -12,7 +12,7 @@ import ktl
 
 from kpf.KPFTranslatorFunction import KPFTranslatorFunction
 from kpf import (log, KPFException, FailedPreCondition, FailedPostCondition,
-                 FailedToReachDestination, check_input)
+                 FailedToReachDestination, check_input, ScriptStopTriggered)
 
 
 ##-----------------------------------------------------------------------------
@@ -100,7 +100,7 @@ def check_scriptstop():
         log.warning("SCRIPTSTOP requested. Resetting SCRIPTSTOP and exiting")
         scriptstop.write('No')
         clear_script_keywords()
-        raise KPFException("SCRIPTSTOP triggered")
+        raise ScriptStopTriggered("SCRIPTSTOP triggered")
     if scriptpause.read() == 'Yes':
         log.warning("SCRIPTPAUSE requested. Waiting for SCRIPTPAUSE=No.")
         expr = f"($kpfconfig.SCRIPTPAUSE == 'No')"

--- a/kpf/spectrograph/ResetDetectors.py
+++ b/kpf/spectrograph/ResetDetectors.py
@@ -6,6 +6,58 @@ from kpf import (log, KPFException, FailedPreCondition, FailedPostCondition,
                  FailedToReachDestination, check_input)
 
 
+class ResetGreenDetector(KPFTranslatorFunction):
+    '''Resets the kpfgreen detector
+
+    ARGS: None
+    '''
+    @classmethod
+    def pre_condition(cls, args, logger, cfg):
+        pass
+
+    @classmethod
+    def perform(cls, args, logger, cfg):
+        expose = ktl.cache('kpfgreen', 'EXPOSE')
+        log.warning(f"Resetting: kpfgreen.EXPOSE = Reset")
+        expose.write('Reset')
+        log.debug('Reset command sent')
+
+    @classmethod
+    def post_condition(cls, args, logger, cfg):
+        expose = ktl.cache('kpfgreen', 'EXPOSE')
+        timeout = cfg.getfloat('times', 'kpfexpose_reset_time', fallback=10)
+        log.warning(f"Waiting for kpfgreen to be Ready")
+        success = expose.waitFor('=="Ready"', timeout=timeout)
+        if success is not True:
+            raise FailedToReachDestination(expose.read(), 'Ready')
+
+
+class ResetRedDetector(KPFTranslatorFunction):
+    '''Resets the kpfred detector
+
+    ARGS: None
+    '''
+    @classmethod
+    def pre_condition(cls, args, logger, cfg):
+        pass
+
+    @classmethod
+    def perform(cls, args, logger, cfg):
+        expose = ktl.cache('kpfred', 'EXPOSE')
+        log.warning(f"Resetting: kpfred.EXPOSE = Reset")
+        expose.write('Reset')
+        log.debug('Reset command sent')
+
+    @classmethod
+    def post_condition(cls, args, logger, cfg):
+        expose = ktl.cache('kpfred', 'EXPOSE')
+        timeout = cfg.getfloat('times', 'kpfexpose_reset_time', fallback=10)
+        log.warning(f"Waiting for kpfred to be Ready")
+        success = expose.waitFor('=="Ready"', timeout=timeout)
+        if success is not True:
+            raise FailedToReachDestination(expose.read(), 'Ready')
+
+
 class ResetDetectors(KPFTranslatorFunction):
     '''Resets the kpfexpose service by setting kpfexpose.EXPOSE = Reset
 

--- a/kpf/spectrograph/SetObserver.py
+++ b/kpf/spectrograph/SetObserver.py
@@ -21,7 +21,7 @@ class SetObserver(KPFTranslatorFunction):
     def perform(cls, args, logger, cfg):
         kpfexpose = ktl.cache('kpfexpose')
         observer = args.get('observer')
-        log.debug(f"Setting OBSERVER to '{observer}'")
+        log.info(f"Setting OBSERVER to '{observer}'")
         kpfexpose['OBSERVER'].write(observer)
         time_shim = cfg.getfloat('times', 'kpfexpose_shim_time', fallback=0.1)
         time.sleep(time_shim)

--- a/kpf/spectrograph/SetProgram.py
+++ b/kpf/spectrograph/SetProgram.py
@@ -24,7 +24,7 @@ class SetProgram(KPFTranslatorFunction):
         progname = args.get('progname')
         log.debug('Waiting for kpfexpose to be ready')
         WaitForReady.execute({})
-        log.debug(f"Setting PROGNAME to '{progname}'")
+        log.info(f"Setting PROGNAME to '{progname}'")
         kpfexpose['PROGNAME'].write(progname)
         time_shim = cfg.getfloat('times', 'kpfexpose_shim_time', fallback=0.1)
         time.sleep(time_shim)

--- a/kpf/utils/BuildOBfromQuery.py
+++ b/kpf/utils/BuildOBfromQuery.py
@@ -13,6 +13,8 @@ def get_names_from_gaiaid(gaiaid):
     hdnumber = '?'
     twomassid = '?'
     names = Simbad.query_objectids(f"Gaia DR3 {gaiaid}")
+    if names is None:
+        return None
     for name in names:
         is2mass = re.match('^2MASS\s+(J[\d\+\-]+)', name[0])
         if is2mass is not None:
@@ -146,6 +148,9 @@ class BuildOBfromQuery(KPFTranslatorFunction):
         OB['GaiaID'] = f"DR3 {gaiaid}"
         # Get target name and 2MASS ID from Gaia ID
         names = get_names_from_gaiaid(gaiaid)
+        if names is None:
+            log.warning(f"Query for {gaiaid} failed to return names")
+            return
         OB['TargetName'] = f"{names['TargetName']}"
         OB['2MASSID'] = f"{names['2MASSID']}"
         # Using 2MASS ID query for Jmag

--- a/kpf/utils/ImageBackIlluminatedFibers.py
+++ b/kpf/utils/ImageBackIlluminatedFibers.py
@@ -27,14 +27,11 @@ class ImageBackIlluminatedFibers(KPFTranslatorFunction):
     @classmethod
     def perform(cls, args, logger, cfg):
         this_file_name = Path(__file__).name.replace('.py', '')
-        utnow = datetime.utcnow()
-        now_str = utnow.strftime('%Y%m%dat%H%M%S')
-        date_str = (utnow-timedelta(days=1)).strftime('%Y%b%d').lower()
-        log_path = Path(f'/s/sdata1701/KPFTranslator_logs/{date_str}')
-        images_file = log_path / Path(f'{this_file_name}_images_{now_str}.txt')
-        images = Table(names=('file', 'camera', 'LED'),
-                       dtype=('a90',  'a10',    'a10'))
-
+        log_path = Path(f'/s/sdata1701/KPFTranslator_logs/')
+        images_file = log_path / Path(f'{this_file_name}_images.txt')
+        hstnow = datetime.now()
+        now_str = hstnow.strftime('%Y-%m-%d %H:%M:%S')
+        
         LEDoutlets = {'Science': 'E7',
                       'Sky': 'E8',
                       'CaHK': 'J7',
@@ -67,12 +64,16 @@ class ImageBackIlluminatedFibers(KPFTranslatorFunction):
             log.info(f'  LASTFILE: {lastfile}')
             log.debug('Turning LED off')
             kpfpower[f"OUTLET_{outlet}"].write('Off')
-            images.add_row({'file': lastfile,
-                            'camera': camera,
-                            'LED': LEDname})
-            if images_file.exists():
-                images_file.unlink()
-            images.write(images_file, format='ascii.csv')
+
+            # Append to images file
+            if images_file.exists() is False:
+                # Write header line
+                header = f"# HST date, camera, LED, file\n"
+                with open(images_file, 'w') as f:
+                    f.write(header)
+            row = f"{now_str}, {camera:4s}, {LEDname:8s}, {lastfile}\n"
+            with open(images_file, 'a') as f:
+                f.write(row)
 
         if args.get('SCI', False) is True:
             take_back_illuminated_image('SCI', 'Science')

--- a/kpf/utils/ImageBackIlluminatedFibers.py
+++ b/kpf/utils/ImageBackIlluminatedFibers.py
@@ -57,7 +57,9 @@ class ImageBackIlluminatedFibers(KPFTranslatorFunction):
                 raise KPFException(f"Expected outlet {outlet} to have name {LEDnames[LEDname]}")
             log.debug('Turning LED on')
             kpfpower[f"OUTLET_{outlet}"].write('On')
-            time.sleep(3)
+
+            # Time shim to let FVC service connect to camera after power up
+            time.sleep(10)
             SetFVCExpTime.execute({'camera': camera,
                                    'exptime': exptimes[camera][LEDname]})
             lastfile = TakeFVCExposure.execute({'camera': camera})

--- a/kpf/utils/ImageBackIlluminatedFibers.py
+++ b/kpf/utils/ImageBackIlluminatedFibers.py
@@ -11,6 +11,8 @@ import ktl
 from kpf.KPFTranslatorFunction import KPFTranslatorFunction
 from kpf import (log, KPFException, FailedPreCondition, FailedPostCondition,
                  FailedToReachDestination, check_input)
+from kpf.fvc.FVCPower import FVCPower
+from kpf.fvc.SetFVCExpTime import SetFVCExpTime
 from kpf.fvc.TakeFVCExposure import TakeFVCExposure
 from kpf.calbench.CalLampPower import CalLampPower
 
@@ -20,68 +22,64 @@ class ImageBackIlluminatedFibers(KPFTranslatorFunction):
     '''
     @classmethod
     def pre_condition(cls, args, logger, cfg):
-        cameras = args.get('cameras', '').split(',')
-        for camera in cameras:
-            if camera not in ['CRED2', 'SCI', 'CAHK', 'EXT', 'ExpMeter']:
-                raise FailedPreCondition(f"Camera {camera} not supported")
+        pass
 
     @classmethod
-    @add_script_log(Path(__file__).name.replace(".py", ""))
     def perform(cls, args, logger, cfg):
-        log.info('-------------------------')
-        log.info(f"Running {cls.__name__}")
-        for key in args:
-            log.debug(f"  {key}: {args[key]}")
-        log.info('-------------------------')
-
         this_file_name = Path(__file__).name.replace('.py', '')
         utnow = datetime.utcnow()
         now_str = utnow.strftime('%Y%m%dat%H%M%S')
         date_str = (utnow-timedelta(days=1)).strftime('%Y%b%d').lower()
-        images_file = Path(f'~/kpflogs/{date_str}/{this_file_name}_images_{now_str}.txt')
+        log_path = Path(f'/s/sdata1701/KPFTranslator_logs/{date_str}')
+        images_file = log_path / Path(f'{this_file_name}_images_{now_str}.txt')
         images = Table(names=('file', 'camera', 'LED'),
                        dtype=('a90',  'a10',    'a10'))
 
-        # Set up FVCs
+        LEDoutlets = {'Science': 'E7',
+                      'Sky': 'E8',
+                      'CaHK': 'J7',
+                      'ExpMeter': 'H1'}
+        LEDnames = {'Science': 'Science Back-Illumination LED',
+                    'Sky': 'Sky Back-Illumination LED',
+                    'CaHK': 'HK Back-Illumination LED',
+                    'ExpMeter': 'Exp Meter Back Illum LED'}
+        exptimes = {'SCI': {'Science': 0.1,
+                            'Sky': 1,
+                            'ExpMeter': 2},
+                    'CAHK': {'CaHK': 5}
+                    }
         kpffvc = ktl.cache('kpffvc')
+        kpfpower = ktl.cache('kpfpower')
 
-        for LED in ['SciLED', 'SkyLED', 'CaHKLED', 'ExpMeterLED']:
-            log.info(f"Imaging with {LED} on")
-            for LEDname in ['SciLED', 'SkyLED', 'CaHKLED', 'ExpMeterLED']:
-                pwr = {True: 'on', False: 'off'}[LED == LEDname]
-                print(LEDname, pwr)
-
-            # Start FVC Exposures
-            nextfile = {}
-            for camera in ['SCI', 'CAHK', 'CAL', 'EXT']:
-                if camera in args.get('cameras', '').split(','):
-                    nextfile[camera] = kpffvc[f"{camera}LASTFILE"].read()
-                    log.debug(f"  Nextfile for {camera} = {nextfile[camera]}")
-                    log.info(f"  Starting {camera} FVC exposure")
-                    TakeFVCExposure.execute({'camera': camera, 'wait': False})
-
-            # Collect files for FVC exposures
-            for camera in ['SCI', 'CAHK', 'CAL', 'EXT']:
-                if camera in args.get('cameras', '').split(','):
-                    log.info(f"  Looking for output file for {camera}")
-                    expr = f'($kpffvc.{camera}LASTFILE == "{nextfile[camera]}")'
-                    log.debug(f"  Waiting for: {expr}")
-                    if ktl.waitFor(expr, timeout=20) is False:
-                        lastfile = kpffvc[f'{camera}LASTFILE'].read()
-                        log.error('No new FVC file found')
-                        log.error(f"  expecting: {nextfile[camera]}")
-                        log.error(f"  kpffvc.{camera}LASTFILE = {lastfile}")
-                    else:
-                        lastfile = kpffvc[f'{camera}LASTFILE'].read()
-                        log.debug(f"Found {lastfile}")
-                        row = {'file': lastfile, 'camera': camera,
-                               'LED': LED}
-                        images.add_row(row)
-
+        def take_back_illuminated_image(camera, LEDname):
+            log.info(f"Taking back illuminated image of {LEDname} fiber with {camera} FVC")
+            FVCPower.execute({'camera': camera, 'power': 'on'})
+            # Take image with Science LED on
+            outlet = LEDoutlets[LEDname]
+            if LEDnames[LEDname] != kpfpower[f"OUTLET_{outlet}_NAME"].read():
+                raise KPFException(f"Expected outlet {outlet} to have name {LEDnames[LEDname]}")
+            log.debug('Turning LED on')
+            kpfpower[f"OUTLET_{outlet}"].write('On')
+            time.sleep(3)
+            SetFVCExpTime.execute({'camera': camera,
+                                   'exptime': exptimes[camera][LEDname]})
+            lastfile = TakeFVCExposure.execute({'camera': camera})
+            log.info(f'  LASTFILE: {lastfile}')
+            log.debug('Turning LED off')
+            kpfpower[f"OUTLET_{outlet}"].write('Off')
+            images.add_row({'file': lastfile,
+                            'camera': camera,
+                            'LED': LEDname})
             if images_file.exists():
                 images_file.unlink()
             images.write(images_file, format='ascii.csv')
 
+        if args.get('SCI', False) is True:
+            take_back_illuminated_image('SCI', 'Science')
+            take_back_illuminated_image('SCI', 'Sky')
+            take_back_illuminated_image('SCI', 'ExpMeter')
+        if args.get('CAHK', False) is True:
+            take_back_illuminated_image('CAHK', 'CaHK')
 
     @classmethod
     def post_condition(cls, args, logger, cfg):
@@ -91,6 +89,12 @@ class ImageBackIlluminatedFibers(KPFTranslatorFunction):
     def add_cmdline_args(cls, parser, cfg=None):
         '''The arguments to add to the command line interface.
         '''
-        parser.add_argument('cameras', type=str,
-                            help='Comma separated list FVC cameras (SCI,CAHK,CAL)')
+        parser.add_argument("--Science", "--Sci", "--science", "--sci", "--SCI",
+                            dest="SCI",
+                            default=False, action="store_true",
+                            help="Image science and sky fibers with science FVC?")
+        parser.add_argument("--CaHK", "--HK", "--cahk", "--hk", "--CAHK",
+                            dest="CAHK",
+                            default=False, action="store_true",
+                            help="Image CaHK fiber with CaHK FVC?")
         return super().add_cmdline_args(parser, cfg)

--- a/kpf/utils/SetObserverFromSchedule.py
+++ b/kpf/utils/SetObserverFromSchedule.py
@@ -1,3 +1,4 @@
+import time
 import requests
 import json
 from datetime import datetime, timedelta
@@ -79,6 +80,7 @@ class SetObserverFromSchedule(KPFTranslatorFunction):
 
         # Set the program
         if progname is None:
+            time.sleep(0.5) # try time shim for log line
             print()
             print(f"  Please enter the program ID for your observations:")
             print()

--- a/kpf/utils/SetObserverFromSchedule.py
+++ b/kpf/utils/SetObserverFromSchedule.py
@@ -1,6 +1,4 @@
 import time
-import requests
-import json
 from datetime import datetime, timedelta
 
 import ktl
@@ -8,32 +6,9 @@ import ktl
 from kpf.KPFTranslatorFunction import KPFTranslatorFunction
 from kpf import (log, KPFException, FailedPreCondition, FailedPostCondition,
                  FailedToReachDestination, check_input)
+from kpf.utils.telsched import get_schedule
 from kpf.spectrograph.SetObserver import SetObserver
 from kpf.spectrograph.SetProgram import SetProgram
-
-
-##-----------------------------------------------------------------------------
-## Functions to interact with telescope DB
-##-----------------------------------------------------------------------------
-def querydb(req):
-    '''A simple wrapper to form a generic API level query to the telescope
-    schedule web API.  Returns a JSON object with the result of the query.
-    '''
-    url = f"https://www.keck.hawaii.edu/software/db_api/telSchedule.php?{req}"
-    r = requests.get(url)
-    return json.loads(r.text)
-
-
-def get_schedule(date, tel):
-    '''Use the querydb function and getSchedule of the telescope schedule web
-    API with arguments for date and telescope number.  Returns a JSON object
-    with the schedule result.
-    '''
-    if tel not in [1,2]:
-        raise KPFError(f"Telescope number in query must be 1 or 2")
-    req = f"cmd=getSchedule&date={date}&telnr={tel}"
-    result = querydb(req)
-    return result
 
 
 ##-----------------------------------------------------------------------------

--- a/kpf/utils/SetObserverFromSchedule.py
+++ b/kpf/utils/SetObserverFromSchedule.py
@@ -56,6 +56,7 @@ class SetObserverFromSchedule(KPFTranslatorFunction):
         log.debug(f"Found {nKPFprograms} KPF programs in schedule for tonight")
         project_codes = [p['ProjCode'] for p in KPF_programs]
 
+        # Look at the schedule to find programs scheduled for tonight
         if nKPFprograms == 0:
             log.warning(f"No KPF programs found on schedule")
             progname = None
@@ -69,29 +70,35 @@ class SetObserverFromSchedule(KPFTranslatorFunction):
                 print(f"  Found {nKPFprograms} KPF programs for tonight:")
                 for project_code in project_codes:
                     print(f"    {project_code}")
-                print(f"  Please entry the program ID for your observations:")
+                print(f"  Please enter the program ID for your observations:")
                 print(f"########################################")
                 print()
                 progname = input()
                 if progname.strip() not in project_codes:
                     log.warning(f"Project code {progname} not on schedule")
+
+        # Set the program
         if progname is None:
-            log.warning(f"Not setting progname or observer values")
+            print()
+            print(f"  Please enter the program ID for your observations:")
+            print()
+            progname = input()
+        if progname == '':
+            log.info('No progname specified')
         else:
-            log.info(f"Setting program to {progname}")
             SetProgram.execute({'progname': progname})
-            this_program = [p for p in KPF_programs if p['ProjCode'] == progname]
-            log.debug(f"Found {len(this_program)} entries for {progname} in schedule for tonight")
-            if len(this_program) > 0:
-                observers = this_program[0]['Observers']
-                log.info(f"Setting PROGNAME={progname} and observer list based on telescope schedule:")
-                log.info(f"{observers}")
-                SetObserver.execute({'observer': observers})
-            else:
-                log.error(f"Failed to set observers. Could not find this program on the schedule.")
-                print()
-                print('To set observers manually use the `kpfSetObserver` command')
-                print()
+
+        # Set Observers
+        this_program = [p for p in KPF_programs if p['ProjCode'] == progname]
+        if len(this_program) > 0:
+            observers = this_program[0]['Observers']
+        else:
+            print()
+            print(f"  Please enter the observer names:")
+            print()
+            observers = input()
+        log.info(f"Setting observer list: {observers}")
+        SetObserver.execute({'observer': observers})
 
     @classmethod
     def post_condition(cls, args, logger, cfg):

--- a/kpf/utils/SetObserverFromSchedule.py
+++ b/kpf/utils/SetObserverFromSchedule.py
@@ -89,6 +89,9 @@ class SetObserverFromSchedule(KPFTranslatorFunction):
                 SetObserver.execute({'observer': observers})
             else:
                 log.error(f"Failed to set observers. Could not find this program on the schedule.")
+                print()
+                print('To set observers manually use the `kpfSetObserver` command')
+                print()
 
     @classmethod
     def post_condition(cls, args, logger, cfg):

--- a/kpf/utils/SetObserverFromSchedule.py
+++ b/kpf/utils/SetObserverFromSchedule.py
@@ -78,13 +78,14 @@ class SetObserverFromSchedule(KPFTranslatorFunction):
         if progname is None:
             log.warning(f"Not setting progname or observer values")
         else:
+            log.info(f"Setting program to {progname}")
+            SetProgram.execute({'progname': progname})
             this_program = [p for p in KPF_programs if p['ProjCode'] == progname]
             log.debug(f"Found {len(this_program)} entries for {progname} in schedule for tonight")
             if len(this_program) > 0:
                 observers = this_program[0]['Observers']
                 log.info(f"Setting PROGNAME={progname} and observer list based on telescope schedule:")
                 log.info(f"{observers}")
-                SetProgram.execute({'progname': progname})
                 SetObserver.execute({'observer': observers})
             else:
                 log.error(f"Failed to set observers. Could not find this program on the schedule.")

--- a/kpf/utils/SetOutdirs.py
+++ b/kpf/utils/SetOutdirs.py
@@ -24,7 +24,7 @@ class SetOutdirs(KPFTranslatorFunction):
         date = utnow-timedelta(days=1)
         date_str = date.strftime('%Y%b%d').lower()
         outdir = Path(f"/s/sdata1701/{os.getlogin()}/{date_str}")
-        magiq_outdir = Path(f"/s/sdata1701/kpfguide")
+        magiq_outdir = Path(f"/s/sdata1701/kpfguide/{date_str}")
         log.debug(f"base outdir: {outdir}")
         log.debug(f"magiq outdir: {magiq_outdir}")
 

--- a/kpf/utils/SetSimulCalSource.py
+++ b/kpf/utils/SetSimulCalSource.py
@@ -25,13 +25,13 @@ class SetSimulCalSource(KPFTranslatorFunction):
     def pre_condition(cls, args, logger, cfg):
         valid_names = ['EtalonFiber', 'U_gold', 'U_daily', 'Th_daily',
                        'Th_gold', 'LFCFiber']
-        if args.get('calsource', None) not in valid_names:
+        if args.get('CalSource', None) not in valid_names:
             raise FailedPreCondition(f"calsource '{calsource}' must be one of {valid_names}")
 
     @classmethod
     def perform(cls, args, logger, cfg):
         log.info(f"Setting simul cal / slew cal source")
-        calsource = args.get('calsource')
+        calsource = args.get('CalSource')
         kpfconfig = ktl.cache('kpfconfig')
         slew_cal_file = Path(f'/kroot/rel/default/data/obs/kpf/SlewCal_{calsource}.yaml')
         if slew_cal_file.exists() is False:

--- a/kpf/utils/SetTargetInfo.py
+++ b/kpf/utils/SetTargetInfo.py
@@ -26,9 +26,24 @@ class SetTargetInfo(KPFTranslatorFunction):
         kpfconfig['TARGET_2MASS'].write(OB.get('2MASSID', ''))
         kpfconfig['TARGET_GMAG'].write(OB.get('Gmag', ''))
         kpfconfig['TARGET_JMAG'].write(OB.get('Jmag', ''))
-        kpf_expmeter['TARGET_TEFF'].write(float(OB.get('Teff', 0)))
-        dcs['TARGPLAX'].write(OB.get('Parallax', 0))
-        dcs['TARGRADV'].write(OB.get('RadialVelocity', 0))
+
+        TARGET_TEFF = OB.get('Teff', 45000)
+        try:
+            kpf_expmeter['TARGET_TEFF'].write(float(TARGET_TEFF))
+        except:
+            log.warning(f"Unable to set kpf_expmeter.TARGET_TEFF to {TARGET_TEFF} ({type(TARGET_TEFF)})")
+
+        TARGPLAX = OB.get('Parallax', 0)
+        try:
+            dcs['TARGPLAX'].write(float(TARGPLAX))
+        except:
+            log.warning(f"Unable to set dcs.TARGPLAX to {TARGPLAX} ({type(TARGPLAX)})")
+
+        TARGRADV = OB.get('RadialVelocity', 0)
+        try:
+            dcs['TARGRADV'].write(float(TARGRADV))
+        except:
+            log.warning(f"Unable to set dcs.TARGRADV to {TARGRADV} ({type(TARGRADV)})")
 
     @classmethod
     def post_condition(cls, args, logger, cfg):

--- a/kpf/utils/StartGUIs.py
+++ b/kpf/utils/StartGUIs.py
@@ -24,7 +24,6 @@ GUI_list = [
              'display': 'control0',
              'position': '0,1000,50,-1,-1'},
             # Control1
-            #   To do: add Spectrograph GUI
             {'name': 'KPF Fiber Injection Unit (FIU)',
              'cmd': ['kpf', 'start', 'fiu_gui'],
              'display': 'control1',
@@ -47,7 +46,6 @@ GUI_list = [
              'display': 'control2',
              'position': '0,1,55,1800,900'},
             # Telstatus
-            #   To do: add Tip Tilt GUI
             {'name': 'MAGIQ - Observer UI',
              'cmd':  ['ssh', '-X', 'k1ruts@k1-magiq-server', 'magiq', 'start', 'ObserverUI'],
              'display': 'telstatus',

--- a/kpf/utils/StartGUIs.py
+++ b/kpf/utils/StartGUIs.py
@@ -22,7 +22,7 @@ GUI_list = [
             {'name': 'KPF TipTilt GUI',
              'cmd': ['kpf', 'start', 'tt_gui'],
              'display': 'control0',
-             'position': '0,800,50,-1,-1'},
+             'position': '0,1000,50,-1,-1'},
             # Control1
             #   To do: add Spectrograph GUI
             {'name': 'KPF Fiber Injection Unit (FIU)',
@@ -41,29 +41,25 @@ GUI_list = [
             {'name': 'Kpf eventsounds',
              'cmd':  ['eventsounds', '-a', 'kpf'],
              'display': 'control2',
-             'position': '0,250,75,-1,-1'},
+             'position': '0,250,20,-1,-1'},
             {'name': 'SAOImage kpfds9',
              'cmd':  ['kpf', 'start', 'kpfds9'],
              'display': 'control2',
              'position': '0,1,55,1800,900'},
             # Telstatus
             #   To do: add Tip Tilt GUI
-            {'name': 'xshow_TipTilt',
-             'cmd':  ['/kroot/rel/default/bin/xshow_tiptilt'],
-             'display': 'telstatus',
-             'position': '0,1020,5,200,310'},
-            {'name': 'KECK 1 FACSUM',
-             'cmd':  ['xterm', '-T', 'xterm KECK 1 FACSUM', '-e', 'ssh', '-X', 'k1ruts@vm-k1obs', 'Facsum', '-k1'],
-             'display': 'telstatus',
-             'position': None},#'0,250,10,-1,-1'},
-            {'name': 'KECK 1 MET',
-             'cmd':  ['xterm', '-T', 'xterm KECK 1 MET', '-e', 'ssh', '-X', 'k1ruts@vm-k1obs', 'Met', '-k1'],
-             'display': 'telstatus',
-             'position': None},#'0,250,535,-1,-1'},
             {'name': 'MAGIQ - Observer UI',
-             'cmd':  ['xterm', '-T', 'xterm MAGIQ - Observer UI', '-e', 'ssh', '-X', 'k1ruts@k1-magiq-server', 'magiq', 'start', 'ObserverUI'],
+             'cmd':  ['ssh', '-X', 'k1ruts@k1-magiq-server', 'magiq', 'start', 'ObserverUI'],
              'display': 'telstatus',
-             'position': None},#'0,500,15,-1,-1'},
+             'position': '0,1225,10,-1,-1'},
+            {'name': 'KECK 1 FACSUM',
+             'cmd':  ['ssh', '-X', 'k1ruts@vm-k1obs', 'Facsum', '-k1'],
+             'display': 'telstatus',
+             'position': '0,250,10,-1,-1'},
+            {'name': 'KECK 1 MET',
+             'cmd':  ['ssh', '-X', 'k1ruts@vm-k1obs', 'Met', '-k1'],
+             'display': 'telstatus',
+             'position': '0,250,535,-1,-1'},
             ]
 
 
@@ -129,16 +125,22 @@ class StartGUIs(KPFTranslatorFunction):
             env['DISPLAY'] = f"kpf{display[GUI['display']]}"
             window_names = get_window_list(env=env)
             GUIname = GUI['name']
-            if GUIname not in window_names:
+            if GUIname not in window_names and args.get('position_only', False) is False:
                 log.info(f"Starting '{GUIname}' GUI")
                 gui_proc = subprocess.Popen(GUI['cmd'], env=env,
                                             stdout=subprocess.PIPE,
                                             stderr=subprocess.PIPE)
                 success = waitfor_window_to_appear(GUIname, env=env)
+                if success is False:
+                    log.error(f'{GUIname} did not come up')
+                    stdout, stderr = gui_proc.communicate()
+                    log.error(f"STDERR: {stderr.decode()}")
+                    log.error(f"STDOUT: {stdout.decode()}")
             else:
                 log.info(f"Existing '{GUIname}' window found")
+                success = True
             time.sleep(2)
-            if GUI.get('position', None) is not None:
+            if GUI.get('position', None) is not None and success is True:
                 log.info(f"Positioning '{GUIname}' GUI")
                 wmctrl_cmd = ['wmctrl', '-r', f'"{GUIname}"', '-e', GUI['position']]
                 log.debug(f"  Running: {' '.join(wmctrl_cmd)}")
@@ -153,3 +155,13 @@ class StartGUIs(KPFTranslatorFunction):
     @classmethod
     def post_condition(cls, args, logger, cfg):
         pass
+
+    @classmethod
+    def add_cmdline_args(cls, parser, cfg=None):
+        '''The arguments to add to the command line interface.
+        '''
+        parser.add_argument("--position", "-p",
+                            dest="position_only",
+                            default=False, action="store_true",
+                            help="Only position the GUIs, do not start")
+        return super().add_cmdline_args(parser, cfg)

--- a/kpf/utils/StartGUIs.py
+++ b/kpf/utils/StartGUIs.py
@@ -18,7 +18,11 @@ GUI_list = [
             {'name': 'KPF OB GUI',
              'cmd': ['/home/kpfeng/ddoi/KPFTranslator/default/KPFTranslator/kpf/OB_GUI/KPF_OB_GUI.py'],
              'display': 'control0',
-             'position': '0,255,35,-1,-1'},
+             'position': '0,5,50,-1,-1'},
+            {'name': 'KPF TipTilt GUI',
+             'cmd': ['kpf', 'start', 'tt_gui'],
+             'display': 'control0',
+             'position': '0,800,50,-1,-1'},
             # Control1
             #   To do: add Spectrograph GUI
             {'name': 'KPF Fiber Injection Unit (FIU)',
@@ -37,7 +41,7 @@ GUI_list = [
             {'name': 'Kpf eventsounds',
              'cmd':  ['eventsounds', '-a', 'kpf'],
              'display': 'control2',
-             'position': None},
+             'position': '0,250,75,-1,-1'},
             {'name': 'SAOImage kpfds9',
              'cmd':  ['kpf', 'start', 'kpfds9'],
              'display': 'control2',

--- a/kpf/utils/telsched.py
+++ b/kpf/utils/telsched.py
@@ -1,0 +1,41 @@
+import requests
+import json
+from datetime import datetime, timedelta
+
+
+##-----------------------------------------------------------------------------
+## Functions to interact with telescope DB
+##-----------------------------------------------------------------------------
+def querydb(req):
+    '''A simple wrapper to form a generic API level query to the telescope
+    schedule web API.  Returns a JSON object with the result of the query.
+    '''
+    url = f"https://www.keck.hawaii.edu/software/db_api/telSchedule.php?{req}"
+    r = requests.get(url)
+    return json.loads(r.text)
+
+
+def get_schedule(date, tel):
+    '''Use the querydb function and getSchedule of the telescope schedule web
+    API with arguments for date and telescope number.  Returns a JSON object
+    with the schedule result.
+    '''
+    if tel not in [1,2]:
+        raise KPFError(f"Telescope number in query must be 1 or 2")
+    req = f"cmd=getSchedule&date={date}&telnr={tel}"
+    result = querydb(req)
+    return result
+
+def when_is_KPF_scheduled(date=None):
+    if date is None:
+        date = datetime.now().strftime('%Y-%m-%d')
+    ut_date = datetime.strptime(date, '%Y-%m-%d') + timedelta(days=1)
+    ut_date_str = ut_date.strftime('%Y-%m-%d')
+    schedule = get_schedule(date, 1)
+    instruments = [s['Instrument'] for s in schedule]
+    for s in schedule:
+        if s['Instrument'] == 'KPF':
+            start_time = datetime.strptime(f"{ut_date_str} {s['StartTime']}", '%Y-%m-%d %H:%M')
+            end_time = datetime.strptime(f"{ut_date_str} {s['EndTime']}", '%Y-%m-%d %H:%M')
+            print(start_time, end_time)
+            print(end_time-start_time)


### PR DESCRIPTION
Changes from development in late-April and May.

Major Changes:
- Support SoCal-SciSky and SoCal-CalFib sources for calibration. Does not interact with SoCal itself, but will allow data to be taken if SoCal has been configured separately.
- Support the kpflamps.%_ENABLED keywords in RunCalOB
- Support taking exposure meter biases and generating a master bias
- Use WaitForTipTilt in RunSciOB (though WaitForTipTilt is simply a sleep for now)
- Add script to take back illuminated fiber images
- Add Fit2DGridSearch tool
- Add code to handle kpfexpose.EXPOSE being stuck in "Start" (recovery code path not tested)
- Add additional support for LFC
- Support kpfconfig.%_ENABLED keywords for detectors

Fixes:
- Fix logic around FIU mode change reties
- Fix AO PCU stage control
- various other bug fixes and improvements