### PR TITLE
Merge changes for next release

### DIFF
--- a/kpf/KPFTranslatorFunction.py
+++ b/kpf/KPFTranslatorFunction.py
@@ -1,6 +1,8 @@
 import os
 from pathlib import Path
 from logging import getLogger
+from argparse import Namespace, ArgumentTypeError
+import copy
 
 from ddoitranslatormodule.BaseFunction import TranslatorModuleFunction
 

--- a/kpf/KPFTranslatorFunction.py
+++ b/kpf/KPFTranslatorFunction.py
@@ -134,7 +134,7 @@ class KPFTranslatorFunction(TranslatorModuleFunction):
         except Exception as e:
             logger.error(f"Exception encountered in post-condition: {e}")
             logger.error(traceback.format_exc(), exc_info=True)
-            raise DDOIPostConditionFailed()
+            raise e
 
         args_diff = cls._diff_args(initial_args, args)
         if args_diff:

--- a/kpf/KPFTranslatorFunction.py
+++ b/kpf/KPFTranslatorFunction.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+import traceback
 from logging import getLogger
 from argparse import Namespace, ArgumentTypeError
 import copy

--- a/kpf/KPFTranslatorFunction.py
+++ b/kpf/KPFTranslatorFunction.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+from logging import getLogger
 
 from ddoitranslatormodule.BaseFunction import TranslatorModuleFunction
 
@@ -48,3 +49,94 @@ class KPFTranslatorFunction(TranslatorModuleFunction):
     @classmethod
     def post_condition(cls, args, logger, cfg):
         pass
+
+    @classmethod
+    def execute(cls, args, logger=None, cfg=None):
+        """Carries out this function in its entirety (pre and post conditions
+           included)
+
+        Parameters
+        ----------
+        args : dict
+            The OB (or portion of OB) in dictionary form
+        logger : DDOILoggerClient, optional
+            The DDOILoggerClient that should be used. If none is provided, defaults to
+            a generic name specified in the config, by default None
+        cfg : filepath, optional
+            File path to the config that should be used, by default None
+
+        Returns
+        -------
+        bool
+            True if execution was sucessful, False otherwise
+
+        Raises
+        ------
+        DDOIArgumentsChangedException
+            If any changes to the input arguments are detected, this exception
+            is raised. Code within a TranslatorModuleFunction should **NOT**
+            change the input arguments
+        """
+        if type(args) == Namespace:
+            args = vars(args)
+        elif type(args) != dict:
+            msg = "argument type must be either Dict or Argparser.Namespace"
+            raise DDOIInvalidArguments(msg)
+
+        # Access the logger and pass it into each method
+        if logger is None:
+            logger = getLogger("")
+
+        # read the config file
+        cfg = cls._load_config(cls, cfg, args=args)
+
+        # Store a copy of the initial args
+        initial_args = copy.deepcopy(args)
+
+        #################
+        # PRE CONDITION #
+        #################
+        try:
+            cls.pre_condition(args, logger, cfg)
+        except Exception as e:
+            logger.error(f"Exception encountered in pre-condition: {e}", exc_info=True)
+            raise e
+
+        args_diff = cls._diff_args(initial_args, args)
+        if args_diff:
+            logger.debug(f"Args changed after pre-condition")
+            logger.debug(f"Before: {initial_args}")
+            logger.debug(f"After: {args}")
+
+        ###########
+        # EXECUTE #
+        ###########
+        try:
+            return_value = cls.perform(args, logger, cfg)
+        except Exception as e:
+            logger.error(f"Exception encountered in perform: {e}", exc_info=True)
+            raise e
+
+        args_diff = cls._diff_args(initial_args, args)
+        if args_diff:
+            logger.debug(f"Args changed after perform")
+            logger.debug(f"Before: {initial_args}")
+            logger.debug(f"After: {args}")
+
+        ##################
+        # POST CONDITION #
+        ##################
+        try:
+            cls.post_condition(args, logger, cfg)
+        except Exception as e:
+            logger.error(f"Exception encountered in post-condition: {e}")
+            logger.error(traceback.format_exc(), exc_info=True)
+            raise DDOIPostConditionFailed()
+
+        args_diff = cls._diff_args(initial_args, args)
+        if args_diff:
+            logger.debug(f"Args changed after post-condition")
+            logger.debug(f"Before: {initial_args}")
+            logger.debug(f"After: {args}")
+
+        return return_value

--- a/kpf/OB_GUI/KPF_OB_GUI.py
+++ b/kpf/OB_GUI/KPF_OB_GUI.py
@@ -39,11 +39,10 @@ def create_GUI_log():
     logdir = Path(f'/s/sdata1701/KPFTranslator_logs/')
     if logdir.exists() is False:
         logdir.mkdir(mode=0o777, parents=True)
-    LogFileName = logdir / 'GUI.log'
-    LogFileHandler = TimedRotatingFileHandler(LogFileName,
-                                              when='D',
-                                              utc=True,  interval=30,
-                                              atTime=datetime.time(0, 0, 0))
+    LogFileName = logdir / 'OB_GUI.log'
+    LogFileHandler = RotatingFileHandler(LogFileName,
+                                         maxBytes=100*1024*1024, # 100 MB
+                                         backupCount=1000) # Keep old files
     LogFileHandler.setLevel(logging.DEBUG)
     LogFileHandler.setFormatter(LogFormat)
     log.addHandler(LogFileHandler)

--- a/kpf/OB_GUI/KPF_OB_GUI.py
+++ b/kpf/OB_GUI/KPF_OB_GUI.py
@@ -4,7 +4,7 @@ import traceback
 import time
 from pathlib import Path
 import logging
-from logging.handlers import TimedRotatingFileHandler
+from logging.handlers import RotatingFileHandler
 import re
 import subprocess
 import yaml

--- a/kpf/__init__.py
+++ b/kpf/__init__.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 import logging
-from logging.handlers import TimedRotatingFileHandler
+from logging.handlers import RotatingFileHandler
 import datetime
 from packaging import version
 

--- a/kpf/__init__.py
+++ b/kpf/__init__.py
@@ -23,10 +23,9 @@ def create_KPF_log():
     if logdir.exists() is False:
         logdir.mkdir(mode=0o777, parents=True)
     LogFileName = logdir / 'KPFTranslator.log'
-    LogFileHandler = TimedRotatingFileHandler(LogFileName,
-                                              when='D',
-                                              utc=True,  interval=30,
-                                              atTime=datetime.time(0, 0, 0))
+    LogFileHandler = RotatingFileHandler(LogFileName,
+                                         maxBytes=100*1024*1024, # 100 MB
+                                         backupCount=1000) # Keep old files
     LogFileHandler.setLevel(logging.DEBUG)
     LogFileHandler.setFormatter(LogFormat)
     log.addHandler(LogFileHandler)

--- a/kpf/expmeter/BuildMasterBias.py
+++ b/kpf/expmeter/BuildMasterBias.py
@@ -5,6 +5,8 @@ import numpy as np
 from astropy.nddata import CCDData
 import ccdproc
 
+import ktl
+
 from kpf.KPFTranslatorFunction import KPFTranslatorFunction
 from kpf import (log, KPFException, FailedPreCondition, FailedPostCondition,
                  FailedToReachDestination, check_input)

--- a/kpf/expmeter/BuildMasterBias.py
+++ b/kpf/expmeter/BuildMasterBias.py
@@ -51,6 +51,9 @@ class BuildMasterBias(KPFTranslatorFunction):
 
         log.info(f"Writing {outputfile}")
         combined_average.write(outputfile, overwrite=True)
+        if args.get('update', False) is True:
+            bias_file = ktl.cache('kpf_expmeter', 'BIAS_FILE')
+            bias_file.write(f"{outputfile}")
 
     @classmethod
     def post_condition(cls, args, logger, cfg):
@@ -65,4 +68,7 @@ class BuildMasterBias(KPFTranslatorFunction):
         parser.add_argument("--output", dest="output", type=str,
                             default='',
                             help="The output combined bias file.")
+        parser.add_argument("--update", dest="update",
+                            default=False, action="store_true",
+                            help="Update the bias file in use with the newly generated file?")
         return super().add_cmdline_args(parser, cfg)

--- a/kpf/expmeter/BuildMasterBias.py
+++ b/kpf/expmeter/BuildMasterBias.py
@@ -33,6 +33,9 @@ class BuildMasterBias(KPFTranslatorFunction):
     @classmethod
     def perform(cls, args, logger, cfg):
         biasfiles = [Path(biasfile) for biasfile in args.get('files')]
+        log.debug(f"Combining {len(biasfiles)} bias frames:")
+        for biasfile in biasfiles:
+            log.debug(f"  {biasfile.name}")
         biases = [CCDData.read(file, unit="adu") for file in biasfiles]
 
         combiner = ccdproc.Combiner(biases)

--- a/kpf/expmeter/SetMasterBiasToDefault.py
+++ b/kpf/expmeter/SetMasterBiasToDefault.py
@@ -1,0 +1,29 @@
+import time
+import ktl
+
+from kpf.KPFTranslatorFunction import KPFTranslatorFunction
+from kpf import (log, KPFException, FailedPreCondition, FailedPostCondition,
+                 FailedToReachDestination, check_input)
+
+
+class SetMasterBiasToDefault(KPFTranslatorFunction):
+    '''Sets the master bias file for the exposure meter to the default value
+    
+    Args:
+    =====
+    None
+    '''
+    @classmethod
+    def pre_condition(cls, args, logger, cfg):
+        pass
+
+    @classmethod
+    def perform(cls, args, logger, cfg):
+        kpf_expmeter = ktl.cache('kpf_expmeter')
+        default_file = '/kroot/rel/default/data/kpf_expmeter/full_bias.fits'
+        log.debug(f"Setting master bias file to {default_file}")
+        kpf_expmeter['BIAS_FILE'].write(default_file)
+
+    @classmethod
+    def post_condition(cls, args, logger, cfg):
+        pass

--- a/kpf/expmeter/TakeExpMeterBiases.py
+++ b/kpf/expmeter/TakeExpMeterBiases.py
@@ -116,7 +116,8 @@ class TakeExpMeterBiases(KPFTranslatorFunction):
 
         if args.get('combine', False) is True:
             BuildMasterBias.execute({'files': biases,
-                                     'output': args.get('output')})
+                                     'output': args.get('output'),
+                                     'update': args.get('update')})
 
         return biases
 
@@ -133,6 +134,9 @@ class TakeExpMeterBiases(KPFTranslatorFunction):
         parser.add_argument("-c", "--combine", dest="combine",
                             default=False, action="store_true",
                             help="Combine the files in to a master bias?")
+        parser.add_argument("--update", dest="update",
+                            default=False, action="store_true",
+                            help="Update the bias file in use with the newly generated file? (only used if --combine is used)")
         parser.add_argument("--output", dest="output", type=str,
                             default='',
                             help="The output combined bias file.")

--- a/kpf/linking_table.yml
+++ b/kpf/linking_table.yml
@@ -70,6 +70,8 @@ links:
         cmd: expmeter.SetExpMeterExptime.SetExpMeterExptime
     PredictExpMeterParameters:
         cmd: expmeter.PredictExpMeterParameters.PredictExpMeterParameters
+    SetMasterBiasToDefault:
+        cmd: expmeter.SetMasterBiasToDefault.SetMasterBiasToDefault
     TakeExpMeterBiases:
         cmd: expmeter.TakeExpMeterBiases.TakeExpMeterBiases
     # FIU

--- a/kpf/scripts/ExecuteCal.py
+++ b/kpf/scripts/ExecuteCal.py
@@ -1,4 +1,5 @@
 import os
+import traceback
 from time import sleep
 from packaging import version
 from pathlib import Path

--- a/kpf/scripts/ExecuteDark.py
+++ b/kpf/scripts/ExecuteDark.py
@@ -1,4 +1,5 @@
 import os
+import traceback
 from time import sleep
 from packaging import version
 from pathlib import Path

--- a/kpf/scripts/ExecuteSci.py
+++ b/kpf/scripts/ExecuteSci.py
@@ -1,4 +1,5 @@
 import os
+import traceback
 from time import sleep
 from packaging import version
 from pathlib import Path

--- a/kpf/scripts/RunCalOB.py
+++ b/kpf/scripts/RunCalOB.py
@@ -160,6 +160,8 @@ class RunCalOB(KPFTranslatorFunction):
             CleanupAfterCalibrations.execute(OB)
             sys.exit(1)
 
+        clear_script_keywords()
+
         # Cleanup: Turn off lamps
         try:
             CleanupAfterCalibrations.execute(OB)

--- a/kpf/scripts/RunCalOB.py
+++ b/kpf/scripts/RunCalOB.py
@@ -123,6 +123,7 @@ class RunCalOB(KPFTranslatorFunction):
                     log.error(f'Sending email failed')
                     log.error(email_err)
             # Cleanup
+            clear_script_keywords()
             log.error('Running CleanupAfterCalibrations and exiting')
             CleanupAfterCalibrations.execute(OB)
             sys.exit(1)
@@ -156,6 +157,7 @@ class RunCalOB(KPFTranslatorFunction):
                     log.error(f'Sending email failed')
                     log.error(email_err)
             # Cleanup
+            clear_script_keywords()
             log.error('Running CleanupAfterCalibrations and exiting')
             CleanupAfterCalibrations.execute(OB)
             sys.exit(1)

--- a/kpf/scripts/RunCalOB.py
+++ b/kpf/scripts/RunCalOB.py
@@ -160,6 +160,7 @@ class RunCalOB(KPFTranslatorFunction):
             CleanupAfterCalibrations.execute(OB)
             sys.exit(1)
 
+        # Clear script keywords so that cleanup can start successfully
         clear_script_keywords()
 
         # Cleanup: Turn off lamps

--- a/kpf/scripts/RunCalOB.py
+++ b/kpf/scripts/RunCalOB.py
@@ -1,3 +1,4 @@
+import sys
 from time import sleep
 from pathlib import Path
 import os
@@ -109,7 +110,6 @@ class RunCalOB(KPFTranslatorFunction):
             log.error(e)
             traceback_text = traceback.format_exc()
             log.error(traceback_text)
-            clear_script_keywords()
             # Email error to kpf_info
             if not isinstance(e, ScriptStopTriggered):
                 try:
@@ -125,7 +125,7 @@ class RunCalOB(KPFTranslatorFunction):
             # Cleanup
             log.error('Running CleanupAfterCalibrations and exiting')
             CleanupAfterCalibrations.execute(OB)
-            raise e
+            sys.exit(1)
 
         # Execute the Cal Sequence
         try:
@@ -143,7 +143,6 @@ class RunCalOB(KPFTranslatorFunction):
             log.error(e)
             traceback_text = traceback.format_exc()
             log.error(traceback_text)
-            clear_script_keywords()
             # Email error to kpf_info
             if not isinstance(e, ScriptStopTriggered):
                 try:
@@ -159,9 +158,7 @@ class RunCalOB(KPFTranslatorFunction):
             # Cleanup
             log.error('Running CleanupAfterCalibrations and exiting')
             CleanupAfterCalibrations.execute(OB)
-            raise e
-
-        clear_script_keywords()
+            sys.exit(1)
 
         # Cleanup: Turn off lamps
         try:

--- a/kpf/scripts/RunCalOB.py
+++ b/kpf/scripts/RunCalOB.py
@@ -132,11 +132,11 @@ class RunCalOB(KPFTranslatorFunction):
             cals = OB.get('SEQ_Calibrations', [])
             for cal in cals:
                 # No need to specify TimedShutter_CaHK in OB/calibration
-                cal['TimedShutter_CaHK'] = OB['TriggerCaHK']
+                cal['TimedShutter_CaHK'] = OB.get('TriggerCaHK', False)
                 log.debug(f"Automatically setting TimedShutter_CaHK: {cal['TimedShutter_CaHK']}")
                 cal['Template_Name'] = 'kpf_lamp'
                 cal['Template_Version'] = OB['Template_Version']
-                cal['nointensemon'] = OB['nointensemon']
+                cal['nointensemon'] = OB.get('nointensemon', False)
                 ExecuteCal.execute(cal)
         except Exception as e:
             log.error("ExecuteCal failed:")

--- a/kpf/scripts/RunSciOB.py
+++ b/kpf/scripts/RunSciOB.py
@@ -1,5 +1,7 @@
+import sys
 import time
 import os
+import traceback
 from pathlib import Path
 
 import ktl
@@ -99,9 +101,14 @@ class RunSciOB(KPFTranslatorFunction):
             except Exception as e:
                 log.error("ExecuteSci failed:")
                 log.error(e)
-        clear_script_keywords()
+                traceback_text = traceback.format_exc()
+                log.error(traceback_text)
+                # Cleanup
+                log.error('Running CleanupAfterScience and exiting')
+                CleanupAfterScience.execute(OB)
+                sys.exit(1)
 
-        # Cleanup: 
+        # Cleanup
         CleanupAfterScience.execute(OB)
 
     @classmethod

--- a/kpf/scripts/RunSciOB.py
+++ b/kpf/scripts/RunSciOB.py
@@ -108,6 +108,8 @@ class RunSciOB(KPFTranslatorFunction):
                 CleanupAfterScience.execute(OB)
                 sys.exit(1)
 
+        clear_script_keywords()
+
         # Cleanup
         CleanupAfterScience.execute(OB)
 

--- a/kpf/scripts/RunSciOB.py
+++ b/kpf/scripts/RunSciOB.py
@@ -108,6 +108,7 @@ class RunSciOB(KPFTranslatorFunction):
                 CleanupAfterScience.execute(OB)
                 sys.exit(1)
 
+        # Clear script keywords so that cleanup can start successfully
         clear_script_keywords()
 
         # Cleanup

--- a/kpf/scripts/RunSciOB.py
+++ b/kpf/scripts/RunSciOB.py
@@ -104,6 +104,7 @@ class RunSciOB(KPFTranslatorFunction):
                 traceback_text = traceback.format_exc()
                 log.error(traceback_text)
                 # Cleanup
+                clear_script_keywords()
                 log.error('Running CleanupAfterScience and exiting')
                 CleanupAfterScience.execute(OB)
                 sys.exit(1)

--- a/kpf/scripts/RunTwilightRVStandard.py
+++ b/kpf/scripts/RunTwilightRVStandard.py
@@ -194,7 +194,7 @@ class RunTwilightRVStandard(KPFTranslatorFunction):
         else:
             StartOfNight.execute({})
 
-        SetProgram.execute({'progname': 'E310'})
+        SetProgram.execute({'progname': 'K444'})
         SetObserver.execute({'observer': 'OA'})
 
         # Wrap operations in try/except to ensure we get to end of night

--- a/kpf/scripts/__init__.py
+++ b/kpf/scripts/__init__.py
@@ -42,7 +42,7 @@ def remove_script_handler(this_file_name):
     log = logging.getLogger('KPFTranslator')
     script_handler_index = None
     for i,handler in enumerate(log.handlers):
-        if isinstance(handler, TimedRotatingFileHandler):
+        if isinstance(handler, RotatingFileHandler):
             filename = Path(handler.baseFilename).name
             if re.search(f"{this_file_name}_", filename) is not None:
                 ScriptLogFileHandler = handler

--- a/kpf/scripts/__init__.py
+++ b/kpf/scripts/__init__.py
@@ -3,7 +3,7 @@ import os
 import socket
 import functools
 import logging
-from logging.handlers import TimedRotatingFileHandler
+from logging.handlers import RotatingFileHandler
 from datetime import datetime, timedelta
 from pathlib import Path
 import re
@@ -21,7 +21,7 @@ from kpf import (log, KPFException, FailedPreCondition, FailedPostCondition,
 def add_script_handler(this_file_name):
     log = logging.getLogger('KPFTranslator')
     for handler in log.handlers:
-        if isinstance(handler, TimedRotatingFileHandler):
+        if isinstance(handler, RotatingFileHandler):
             kpflog_filehandler = handler
     ## Set up script log file
     utnow = datetime.utcnow()

--- a/kpf/spectrograph/ResetDetectors.py
+++ b/kpf/spectrograph/ResetDetectors.py
@@ -195,10 +195,6 @@ class RecoverDetectors(KPFTranslatorFunction):
                 ResetCaHKDetector.execute({})
             if kpfmon['E_STATESTA'].read() == 'ERROR':
                 ResetExpMeterDetector.execute({})
-            expose = ktl.cache('kpfexpose', 'EXPOSE')
-            ready = expose.waitFor("== 'Ready'", timeout=timeout)
-            if ready is False:
-                expose.write('Reset')
         else:
             log.warning(f'kpfmon.CAMSTATESTA={camera_status}. No action taken.')
 

--- a/kpf/spectrograph/ResetDetectors.py
+++ b/kpf/spectrograph/ResetDetectors.py
@@ -65,16 +65,19 @@ class ResetGreenDetector(KPFTranslatorFunction):
     '''
     @classmethod
     def pre_condition(cls, args, logger, cfg):
-        expstate = ktl.cache('kpfgreen', 'EXPSTATE')
-        if expstate.read() == 'Resetting':
-            raise FailedPreCondition('Reset already in progress')
+        pass
 
     @classmethod
     def perform(cls, args, logger, cfg):
-        expose = ktl.cache('kpfgreen', 'EXPOSE')
-        log.warning(f"Resetting: kpfgreen.EXPOSE = Reset")
-        expose.write('Reset')
-        log.debug('Reset command sent')
+        # Check if the auto reset is already doing this
+        expstate = ktl.cache('kpfgreen', 'EXPSTATE')
+        if expstate.read() == 'Resetting':
+            return
+        else:
+            expose = ktl.cache('kpfgreen', 'EXPOSE')
+            log.warning(f"Resetting: kpfgreen.EXPOSE = Reset")
+            expose.write('Reset')
+            log.debug('Reset command sent')
 
     @classmethod
     def post_condition(cls, args, logger, cfg):
@@ -100,16 +103,19 @@ class ResetRedDetector(KPFTranslatorFunction):
     '''
     @classmethod
     def pre_condition(cls, args, logger, cfg):
-        expstate = ktl.cache('kpfred', 'EXPSTATE')
-        if expstate.read() == 'Resetting':
-            raise FailedPreCondition('Reset already in progress')
+        pass
 
     @classmethod
     def perform(cls, args, logger, cfg):
-        expose = ktl.cache('kpfred', 'EXPOSE')
-        log.warning(f"Resetting: kpfred.EXPOSE = Reset")
-        expose.write('Reset')
-        log.debug('Reset command sent')
+        # Check if the auto reset is already doing this
+        expstate = ktl.cache('kpfred', 'EXPSTATE')
+        if expstate.read() == 'Resetting':
+            return
+        else:
+            expose = ktl.cache('kpfred', 'EXPOSE')
+            log.warning(f"Resetting: kpfred.EXPOSE = Reset")
+            expose.write('Reset')
+            log.debug('Reset command sent')
 
     @classmethod
     def post_condition(cls, args, logger, cfg):

--- a/kpf/spectrograph/ResetDetectors.py
+++ b/kpf/spectrograph/ResetDetectors.py
@@ -112,7 +112,7 @@ class ResetRedDetector(KPFTranslatorFunction):
     @classmethod
     def perform(cls, args, logger, cfg):
         # Check if the auto reset is already doing this
-        expstate = ktl.cache('kpfred', 'EXPSTATE')
+        current_expstate = ktl.cache('kpfred', 'EXPSTATE')
         current_expstate.read()
         if current_expstate == 'Resetting':
             return

--- a/kpf/spectrograph/ResetDetectors.py
+++ b/kpf/spectrograph/ResetDetectors.py
@@ -71,13 +71,17 @@ class ResetGreenDetector(KPFTranslatorFunction):
     def perform(cls, args, logger, cfg):
         # Check if the auto reset is already doing this
         expstate = ktl.cache('kpfgreen', 'EXPSTATE')
-        if expstate.read() == 'Resetting':
+        current_expstate.read()
+        if current_expstate == 'Resetting':
             return
-        else:
-            expose = ktl.cache('kpfgreen', 'EXPOSE')
-            log.warning(f"Resetting: kpfgreen.EXPOSE = Reset")
-            expose.write('Reset')
-            log.debug('Reset command sent')
+        elif current_expstate == 'Exposing':
+            expstate.write('End')
+            expstate.waitFor('!= "Exposing"')
+        # Send the reset
+        expose = ktl.cache('kpfgreen', 'EXPOSE')
+        log.warning(f"Resetting: kpfgreen.EXPOSE = Reset")
+        expose.write('Reset')
+        log.debug('Reset command sent')
 
     @classmethod
     def post_condition(cls, args, logger, cfg):
@@ -109,13 +113,17 @@ class ResetRedDetector(KPFTranslatorFunction):
     def perform(cls, args, logger, cfg):
         # Check if the auto reset is already doing this
         expstate = ktl.cache('kpfred', 'EXPSTATE')
-        if expstate.read() == 'Resetting':
+        current_expstate.read()
+        if current_expstate == 'Resetting':
             return
-        else:
-            expose = ktl.cache('kpfred', 'EXPOSE')
-            log.warning(f"Resetting: kpfred.EXPOSE = Reset")
-            expose.write('Reset')
-            log.debug('Reset command sent')
+        elif current_expstate == 'Exposing':
+            expstate.write('End')
+            expstate.waitFor('!= "Exposing"')
+        # Send the reset
+        expose = ktl.cache('kpfred', 'EXPOSE')
+        log.warning(f"Resetting: kpfred.EXPOSE = Reset")
+        expose.write('Reset')
+        log.debug('Reset command sent')
 
     @classmethod
     def post_condition(cls, args, logger, cfg):

--- a/kpf/spectrograph/ResetDetectors.py
+++ b/kpf/spectrograph/ResetDetectors.py
@@ -75,8 +75,8 @@ class ResetGreenDetector(KPFTranslatorFunction):
         if current_expstate == 'Resetting':
             return
         elif current_expstate == 'Exposing':
-            expstate.write('End')
-            expstate.waitFor('!= "Exposing"')
+            log.warning('Can not send reset during exposure')
+            return
         # Send the reset
         expose = ktl.cache('kpfgreen', 'EXPOSE')
         log.warning(f"Resetting: kpfgreen.EXPOSE = Reset")
@@ -117,8 +117,8 @@ class ResetRedDetector(KPFTranslatorFunction):
         if current_expstate == 'Resetting':
             return
         elif current_expstate == 'Exposing':
-            expstate.write('End')
-            expstate.waitFor('!= "Exposing"')
+            log.warning('Can not send reset during exposure')
+            return
         # Send the reset
         expose = ktl.cache('kpfred', 'EXPOSE')
         log.warning(f"Resetting: kpfred.EXPOSE = Reset")

--- a/kpf/spectrograph/ResetDetectors.py
+++ b/kpf/spectrograph/ResetDetectors.py
@@ -70,7 +70,7 @@ class ResetGreenDetector(KPFTranslatorFunction):
     @classmethod
     def perform(cls, args, logger, cfg):
         # Check if the auto reset is already doing this
-        expstate = ktl.cache('kpfgreen', 'EXPSTATE')
+        current_expstate  = ktl.cache('kpfgreen', 'EXPSTATE')
         current_expstate.read()
         if current_expstate == 'Resetting':
             return

--- a/kpf/spectrograph/StartExposure.py
+++ b/kpf/spectrograph/StartExposure.py
@@ -53,6 +53,7 @@ class StartExposure(KPFTranslatorFunction):
                 log.warning('Stopping current exposure (with read out)')
                 kpfexpose['EXPOSE'].write('End')
                 time.sleep(2) # Time shim, this time is a WAG
+            WaitForReadout.execute({})
             # Now reset the offending detector
             if 'Green' in trig_targ:
                 green_expstate = ktl.cache('kpfgreen', 'EXPSTATE').read()

--- a/kpf/spectrograph/StartExposure.py
+++ b/kpf/spectrograph/StartExposure.py
@@ -29,15 +29,28 @@ class StartExposure(KPFTranslatorFunction):
 
     @classmethod
     def post_condition(cls, args, logger, cfg):
-        expr = f"(kpfexpose.EXPOSE != Start or kpfmon.CAMSTATESTA == ERROR)"
-        timeout = 7 # This is to allow 5s for kpfmon.CAMSTATESTA to work
-        error_or_exposure_inprogress = ktl.waitFor(expr, timeout=timeout)
-        if error_or_exposure_inprogress == True:
-            # We didn't time out, so which state is it?
-            kpfmon = ktl.cache('kpfmon')
-            camstatesta = kpfmon['CAMSTATESTA'].read()
-            if camstatesta == 'ERROR':
-                log.error('kpfexpose.CAMSTATESTA is ERROR')
+        expr = f"(kpfexpose.EXPOSE != Start)"
+        kpfexpose = ktl.cache('kpfexpose')
+        trig_targ = kpfexpose['TRIG_TARG'].read().split(',')
+        if 'Green' in trig_targ:
+            expr += ' and ($kpfgreen.EXPSTATE != Start)'
+        if 'Red' in trig_targ:
+            expr += ' and ($kpfred.EXPSTATE != Start)'
+        if 'Ca_HK' in trig_targ:
+            expr += ' and ($kpf_hk.EXPSTATE != Start)'
+        timeout = 5
+        left_start_state = ktl.waitFor(expr, timeout=timeout)
+        if left_start_state is not True:
+            log.error(f'We are still in start state after {timeout} s')
+            if 'Green' in trig_targ:
+                green_expstate = ktl.cache('kpfgreen', 'EXPSTATE')
+                log.debug(f'kpfgreen.EXPSTATE = {green_expstate.read()}')
+            if 'Red' in trig_targ:
+                red_expstate = ktl.cache('kpfred', 'EXPSTATE')
+                log.debug(f'kpfred.EXPSTATE = {red_expstate.read()}')
+            if 'Ca_HK' in trig_targ:
+                cahk_expstate = ktl.cache('kpf_hk', 'EXPSTATE')
+                log.debug(f'kpf_hk.EXPSTATE = {cahk_expstate.read()}')
                 RecoverDetectors.execute({})
                 # Now we want to abort the current exposure and start again
                 log.warning('Stopping current exposure (with read out)')
@@ -45,11 +58,30 @@ class StartExposure(KPFTranslatorFunction):
                 expose.write('End')
                 WaitForReady.execute({})
                 StartExposure.execute(args)
-            else:
-                # We must have transitioned properly
-                expose = ktl.cache('kpfexpose', 'EXPOSE')
-                log.debug(f'Post condition succeeded: kpfmon.CAMSTATESTA={camstatesta}, kpfexpose.EXPOSE={expose.read()}')
-        else:
-            # We timed out, not sure what is going on
-            msg = f"Neither kpfmon.CAMSTATESTA nor kpfexpose.EXPOSE transitioned as expected"
-            raise KPFException(msg)
+
+#     @classmethod
+#     def post_condition(cls, args, logger, cfg):
+#         expr = f"(kpfexpose.EXPOSE != Start or kpfmon.CAMSTATESTA == ERROR)"
+#         timeout = 7 # This is to allow 5s for kpfmon.CAMSTATESTA to work
+#         error_or_exposure_inprogress = ktl.waitFor(expr, timeout=timeout)
+#         if error_or_exposure_inprogress == True:
+#             # We didn't time out, so which state is it?
+#             kpfmon = ktl.cache('kpfmon')
+#             camstatesta = kpfmon['CAMSTATESTA'].read()
+#             if camstatesta == 'ERROR':
+#                 log.error('kpfexpose.CAMSTATESTA is ERROR')
+#                 RecoverDetectors.execute({})
+#                 # Now we want to abort the current exposure and start again
+#                 log.warning('Stopping current exposure (with read out)')
+#                 expose = ktl.cache('kpfexpose', 'EXPOSE')
+#                 expose.write('End')
+#                 WaitForReady.execute({})
+#                 StartExposure.execute(args)
+#             else:
+#                 # We must have transitioned properly
+#                 expose = ktl.cache('kpfexpose', 'EXPOSE')
+#                 log.debug(f'Post condition succeeded: kpfmon.CAMSTATESTA={camstatesta}, kpfexpose.EXPOSE={expose.read()}')
+#         else:
+#             # We timed out, not sure what is going on
+#             msg = f"Neither kpfmon.CAMSTATESTA nor kpfexpose.EXPOSE transitioned as expected"
+#             raise KPFException(msg)

--- a/kpf/spectrograph/StartExposure.py
+++ b/kpf/spectrograph/StartExposure.py
@@ -35,7 +35,8 @@ class StartExposure(KPFTranslatorFunction):
         if error_or_exposure_inprogress == True:
             # We didn't time out, so which state is it?
             kpfmon = ktl.cache('kpfmon')
-            if kpfmon['CAMSTATESTA'].read() == 'ERROR':
+            camstatesta = kpfmon['CAMSTATESTA'].read()
+            if camstatesta == 'ERROR':
                 log.error('kpfexpose.CAMSTATESTA is ERROR')
                 RecoverDetectors.execute({})
                 # Now we want to abort the current exposure and start again
@@ -46,7 +47,8 @@ class StartExposure(KPFTranslatorFunction):
                 StartExposure.execute(args)
             else:
                 # We must have transitioned properly
-                pass
+                expose = ktl.cache('kpfexpose', 'EXPOSE')
+                log.debug(f'Post condition succeeded: kpfmon.CAMSTATESTA={camstatesta}, kpfexpose.EXPOSE={expose.read()}')
         else:
             # We timed out, not sure what is going on
             msg = f"Neither kpfmon.CAMSTATESTA nor kpfexpose.EXPOSE transitioned as expected"

--- a/kpf/spectrograph/StartExposure.py
+++ b/kpf/spectrograph/StartExposure.py
@@ -43,33 +43,31 @@ class StartExposure(KPFTranslatorFunction):
         left_start_state = ktl.waitFor(expr, timeout=timeout)
         if left_start_state is False:
             log.error(f'We are still in start state after {timeout} s')
+            # Figure out which detector is stuck in the start state?
+            green_expstate = ktl.cache('kpfgreen', 'EXPSTATE').read()
+            log.debug(f'kpfgreen.EXPSTATE = {green_expstate}')
+            red_expstate = ktl.cache('kpfred', 'EXPSTATE').read()
+            log.debug(f'kpfred.EXPSTATE = {red_expstate}')
+            cahk_expstate = ktl.cache('kpf_hk', 'EXPSTATE').read()
+            log.debug(f'kpf_hk.EXPSTATE = {cahk_expstate}')
             # Abort the current exposure
             elapsed = kpfexpose['ELAPSED'].read(binary=True)
             remaining = exptime-elapsed
             if remaining <= 10:
                 # Don't stop exposure, just wait it out
-                pass
+                log.debug(f'Waiting out remaining {remaining} s of exposure')
+                time.sleep(remaining+2)
             else:
                 log.warning('Stopping current exposure (with read out)')
                 kpfexpose['EXPOSE'].write('End')
                 time.sleep(2) # Time shim, this time is a WAG
-            WaitForReadout.execute({})
             # Now reset the offending detector
-            if 'Green' in trig_targ:
-                green_expstate = ktl.cache('kpfgreen', 'EXPSTATE').read()
-                log.debug(f'kpfgreen.EXPSTATE = {green_expstate}')
-                if green_expstate == 'Start':
-                    ResetGreenDetector.execute({})
-            if 'Red' in trig_targ:
-                red_expstate = ktl.cache('kpfred', 'EXPSTATE').read()
-                log.debug(f'kpfred.EXPSTATE = {red_expstate}')
-                if red_expstate == 'Start':
-                    ResetRedDetector.execute({})
-            if 'Ca_HK' in trig_targ:
-                cahk_expstate = ktl.cache('kpf_hk', 'EXPSTATE').read()
-                log.debug(f'kpf_hk.EXPSTATE = {cahk_expstate}')
-                if cahk_expstate == 'Start':
-                    ResetCaHKDetector.execute({})
+            if green_expstate == 'Start':
+                ResetGreenDetector.execute({})
+            if red_expstate == 'Start':
+                ResetRedDetector.execute({})
+            if cahk_expstate == 'Start':
+                ResetCaHKDetector.execute({})
             # Now start a fresh exposure
             WaitForReady.execute({})
             log.warning('Restarting exposure')

--- a/kpf/spectrograph/StartExposure.py
+++ b/kpf/spectrograph/StartExposure.py
@@ -1,4 +1,4 @@
-import numpy as np
+import time
 
 import ktl
 
@@ -40,24 +40,37 @@ class StartExposure(KPFTranslatorFunction):
             expr += ' and ($kpf_hk.EXPSTATE != Start)'
         timeout = 5
         left_start_state = ktl.waitFor(expr, timeout=timeout)
-        if left_start_state is not True:
+        if left_start_state is False:
             log.error(f'We are still in start state after {timeout} s')
             if 'Green' in trig_targ:
-                green_expstate = ktl.cache('kpfgreen', 'EXPSTATE')
-                log.debug(f'kpfgreen.EXPSTATE = {green_expstate.read()}')
+                green_expstate = ktl.cache('kpfgreen', 'EXPSTATE').read()
+                log.debug(f'kpfgreen.EXPSTATE = {green_expstate}')
             if 'Red' in trig_targ:
-                red_expstate = ktl.cache('kpfred', 'EXPSTATE')
-                log.debug(f'kpfred.EXPSTATE = {red_expstate.read()}')
+                red_expstate = ktl.cache('kpfred', 'EXPSTATE').read()
+                log.debug(f'kpfred.EXPSTATE = {red_expstate}')
             if 'Ca_HK' in trig_targ:
-                cahk_expstate = ktl.cache('kpf_hk', 'EXPSTATE')
-                log.debug(f'kpf_hk.EXPSTATE = {cahk_expstate.read()}')
-                RecoverDetectors.execute({})
-                # Now we want to abort the current exposure and start again
-                log.warning('Stopping current exposure (with read out)')
-                expose = ktl.cache('kpfexpose', 'EXPOSE')
-                expose.write('End')
-                WaitForReady.execute({})
-                StartExposure.execute(args)
+                cahk_expstate = ktl.cache('kpf_hk', 'EXPSTATE').read()
+                log.debug(f'kpf_hk.EXPSTATE = {cahk_expstate}')
+
+            # Now we want to abort the current exposure and start again
+            log.warning('Stopping current exposure (with read out)')
+            kpfexpose['EXPOSE'].write('End')
+            time.sleep(2) # Time shim, this time is a WAG
+
+            # This logic is based on the earlier reading of the state, before
+            # the exposure was ended
+            if 'Green' in trig_targ:
+                if green_expstate == 'Start':
+                    ResetGreenDetector.execute({})
+            if 'Red' in trig_targ:
+                if red_expstate == 'Start':
+                    ResetRedDetector.execute({})
+            if 'Ca_HK' in trig_targ:
+                if cahk_expstate == 'Start':
+                    ResetCaHKDetector.execute({})
+
+            WaitForReady.execute({})
+            StartExposure.execute(args)
 
 #     @classmethod
 #     def post_condition(cls, args, logger, cfg):

--- a/kpf/utils/EstimateOBDuration.py
+++ b/kpf/utils/EstimateOBDuration.py
@@ -63,16 +63,17 @@ class EstimateCalOBDuration(KPFTranslatorFunction):
         readout = max([readout_red, readout_green, readout_cahk])
 
         # ConfigureForCalibrations
-        sequence = OB.get('SEQ_Calibrations')
-        lamps = set([x['CalSource'] for x in sequence if x['CalSource'] != 'Home'])
-        for lamp in lamps:
-            if lamp in ['Th_daily', 'Th_gold', 'U_daily', 'U_gold',
-                        'BrdbandFiber', 'WideFlat']:
-                duration += cfg.getfloat('time_estimates', 'power_on_cal_lamp',
-                                    fallback=1)
-            if lamp == 'LFCFiber':
-                duration += cfg.getfloat('time_estimates', 'LFC_to_AstroComb',
-                                    fallback=30)
+        sequence = OB.get('SEQ_Calibrations', [])
+        if len(sequence) > 0:
+            lamps = set([x['CalSource'] for x in sequence if x['CalSource'] != 'Home'])
+            for lamp in lamps:
+                if lamp in ['Th_daily', 'Th_gold', 'U_daily', 'U_gold',
+                            'BrdbandFiber', 'WideFlat']:
+                    duration += cfg.getfloat('time_estimates', 'power_on_cal_lamp',
+                                        fallback=1)
+                if lamp == 'LFCFiber':
+                    duration += cfg.getfloat('time_estimates', 'LFC_to_AstroComb',
+                                        fallback=30)
         # Configure FIU
         duration += cfg.getfloat('time_estimates', 'FIU_mode_change',
                             fallback=20)

--- a/kpf/utils/EstimateOBDuration.py
+++ b/kpf/utils/EstimateOBDuration.py
@@ -85,8 +85,8 @@ class EstimateCalOBDuration(KPFTranslatorFunction):
             duration += cfg.getfloat('time_estimates', 'octagon_move',
                                 fallback=60)
         for dark in darks:
-            duration += dark['nExp']*dark['ExpTime']
-            duration += dark['nExp']*readout
+            duration += int(dark['nExp'])*float(dark['ExpTime'])
+            duration += int(dark['nExp'])*readout
 
         # Execute Cals
         cals = OB.get('SEQ_Calibrations', [])
@@ -111,8 +111,8 @@ class EstimateCalOBDuration(KPFTranslatorFunction):
                     print(f"  {lamp} warm up {warm_up_wait/60:.0f} min")
                     duration += warm_up_wait
                 lamps_that_need_warmup.pop(lamps_that_need_warmup.index(lamp))
-            duration += cal['nExp']*max([cal['ExpTime'], archon_time_shim])
-            duration += cal['nExp']*readout
+            duration += int(cal['nExp'])*max([float(cal['ExpTime']), archon_time_shim])
+            duration += int(cal['nExp'])*readout
 
         print(f"{duration/60:.0f} min")
         return duration


### PR DESCRIPTION
v1.1.1 Change log:
- The scripts executing calibration and science exposures now detect start state errors on red and green detectors and will automatically abort the bad exposure and start a new one.
- Refactored master bias creation for exposure meter
- Convert loggers to file sized based rotation
- Make tracebacks cleaner by raising KPF exceptions instead of DDOI exceptions + better handling of errors in high level scripts `RunCalOB` and `RunSciOB`.
- Various bug fixes and improvements.