### PR TITLE
v2.0.3

### DIFF
--- a/docs/detectors.md
+++ b/docs/detectors.md
@@ -13,7 +13,7 @@ The Ca H&K spectrograph has its own, separate timed shutter as it is on a comple
 | Parameter | Green CCD | Red CCD | Ca H&K CCD |
 | --------- | --------- | ------- | ---------- |
 | Readout Time | 47 s | 47 s | 1 s |
-| Read Noise | AMP1: 4.0 e-<br>AMP2: 4.9 e- | AMP1: 4.1 e-<br>AMP2: 4.2 e- |  |
+| Read Noise | see [status page](status.md) | AMP1: 4.3 e-<br>AMP2: 4.3 e- |  |
 | Format | 4080x4080 | 4080x4080 | windowed to<br>1024x255 |
 | Gain | ~5 e-/ADU | ~5 e-/ADU | 5.26 e-/ADU |
 | Data Format | 32 bit | 32 bit | 16 bit |

--- a/docs/status.md
+++ b/docs/status.md
@@ -9,12 +9,12 @@
 
 This is an attempt to summarize the status of various sub-systems of the instrument.  Each sub-system name is color coded to indicate the status at a glance: <font color="green">green</font> means functioning normally, <font color="orange">orange</font> means mostly normal, but with some caveats or minor issues, and <font color="red">red</font> means the sub-system is compromised in some way.
 
-Last Status Update: 2025-08-15
+Last Status Update: 2025-10-22
 
-- **<font color="red">Detector Noise</font>**: Starting in November of 2024, additional pattern noise has been present on the detectors.  We have been working on eliminating the spurious nose, but we have been unable to completely remove it.  As of late-April 2025 the read noise in the various amplifiers is between 12 and 13.5 electrons.
-- **<font color="red">LFC</font>**: Currently unreliable. 
+- **<font color="orange">Detector Noise</font>**: Starting in November of 2024, additional pattern noise has been present on the detectors.  We have been working on eliminating the spurious nose, but we have been unable to completely remove it.  As of late-October 2025 the read noise on the Green side remains elevated (~10 electrons), while the red side is near our nominal target (~4.3 electrons).
+- **<font color="orange">LFC</font>**: We are evaluating the reliability of the LFC after recent service. Initial indications look prominsing on reliability, though the bluest flux (below ~490 nm) is not consistent.
 - **<font color="green">Etalon</font>**: Operational.
-- **<font color="orange">Detector Cooling Systems</font>**: Both detectors are now cooled with closed cycle refrigerators (CCRs). The green side CCR has some lingering problems and has very little overhead on maintaining temperature and has occasional deviations which affect the detector.  Red side is performing well.
+- **<font color="red">Detector Cooling Systems</font>**: Both detectors are now cooled with closed cycle refrigerators (CCRs). The green side CCR has  problems and has very little overhead on maintaining temperature and has quasi-periodic deviations which affect the detector.  Red side is performing well.
 - **<font color="green">Detector Errors</font>**: The red and green detectors suffer from occasional “start state errors” in which the affected detector remains in the start phase and does not produce a useful exposure. The observing scripts detect this, abort the current exposure (with read out) and start a fresh exposure on both cameras. **No action is necessary on the part of the observer.**  The occurrence rate is such that around one in every 180 exposures is affected by one of the two detectors experiencing this error.
 - **<font color="green">Ca H&K Detector</font>**: The CA H&K detector is operational.
 - **<font color="green">Exposure Meter Terminated Exposures</font>**: Operational.

--- a/kpf/KPFTranslatorFunction.py
+++ b/kpf/KPFTranslatorFunction.py
@@ -97,6 +97,18 @@ class KPFScript(KPFFunction):
     addition to a dict of arguments.
     '''
     @classmethod
+    def pre_condition(cls, args, OB=None):
+        pass
+
+    @classmethod
+    def post_condition(cls, args, OB=None):
+        pass
+
+    @classmethod
+    def perform(cls, args, OB=None):
+        pass
+
+    @classmethod
     def execute(cls, args, OB=None):
         """Carries out this function in its entirety (pre and post conditions
            included)

--- a/kpf/OB_GUI/HistoryListModel.py
+++ b/kpf/OB_GUI/HistoryListModel.py
@@ -45,7 +45,7 @@ class HistoryListModel(QtCore.QAbstractListModel):
             return QtGui.QImage(f'{self.icon_path}/tick.png')
 
     def refresh_history(self, history):
-        self.log.debug(f'refresh_history')
+        self.log.debug(f'HistoryListModel refresh_history: {history}')
         self.exposures = []
         self.exposure_start_times = []
         for i,h in enumerate(history):

--- a/kpf/OB_GUI/KPF_OB_GUI.py
+++ b/kpf/OB_GUI/KPF_OB_GUI.py
@@ -874,6 +874,7 @@ class MainWindow(QtWidgets.QMainWindow):
         OBs_for_list = [self.OBcache[obid] for obid in self.KPFCC_OBs[WB]]
         self.OBListModel.set_list(OBs_for_list,
                                   start_times=self.KPFCC_start_times[WB])
+        self.refresh_history()
 
 
     ##-------------------------------------------

--- a/kpf/OB_GUI/KPF_OB_GUI.py
+++ b/kpf/OB_GUI/KPF_OB_GUI.py
@@ -708,11 +708,18 @@ class MainWindow(QtWidgets.QMainWindow):
         self.SiderealTimeValue.setText(value[:-3])
         self.update_counter += 1
         if self.update_counter > 180:
-            self.log.debug('Updating: SOB info, telescope_released, and history')
+            self.log.debug('Updating: SOB info, telescope_released')
             self.update_counter = 0
             self.update_SOB_display() # Updates alt, az
             self.telescope_released = GetTelescopeRelease.execute({})
-            self.refresh_history()
+            # Update execution history if we're vaguely near observing times
+            try:
+                UTh = int(self.UTValue.text().split(':')[0])
+            except:
+                UTh = 0
+            if UTh >= 3 and UTh <= 17:
+                self.log.debug('Updating: execution history')
+                self.refresh_history()
 
 
     ##-------------------------------------------

--- a/kpf/OB_GUI/KPF_OB_GUI.py
+++ b/kpf/OB_GUI/KPF_OB_GUI.py
@@ -1108,7 +1108,6 @@ class MainWindow(QtWidgets.QMainWindow):
         self.refresh_history()
         self.set_SortOrWeather()
         # Pop up for any errors
-        print(type(errs), errs)
         if len(errs) > 0:
             ConfirmationPopup('Errors retrieving OBs:', errs, info_only=True, warning=True).exec_()
 

--- a/kpf/OB_GUI/KPF_OB_GUI.py
+++ b/kpf/OB_GUI/KPF_OB_GUI.py
@@ -192,6 +192,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.schedule_path = Path(f'/s/sdata1701/Schedules/')
         self.KPFCC_weather_bands = ['band1', 'band2', 'band3']
         self.KPFCC_weather_band = self.KPFCC_weather_bands[0]
+        self.OBcache = {}
         self.KPFCC_OBs = {}
         self.KPFCC_start_times = {}
         for WB in self.KPFCC_weather_bands:
@@ -209,22 +210,22 @@ class MainWindow(QtWidgets.QMainWindow):
         self.BuildCalibration = [Calibration({})]
         # Example Calibrations
         try:
-            self.slewcalOB = ObservingBlock(self.SLEWCALFILE.ascii)
+            self.OBcache['slewcal'] = ObservingBlock(self.SLEWCALFILE.ascii)
         except Exception as e:
             self.log.warning(f'Faied to load slewcal file: {self.SLEWCALFILE.ascii}')
             self.log.debug(e)
             try:
                 self.log.debug('Loading temporary slewcal OB')
-                self.slewcalOB = ObservingBlock('/s/sdata1701/OBs/jwalawender/Calibrations/SlewCal_EtalonFiber.yaml')
+                self.OBcache['slewcal'] = ObservingBlock('/s/sdata1701/OBs/jwalawender/Calibrations/SlewCal_EtalonFiber.yaml')
             except:
-                self.slewcalOB = None
-        if self.slewcalOB is not None:
+                self.OBcache['slewcal'] = None
+        if self.OBcache['slewcal'] is not None:
             comment = ['This is a pure calibration OB, so the FIU will be in ',
                        'calibration or stow mode when this finishes.\n\n',
                        'Run "FIU->Configure FIU for Observing" from the Menu ',
                        'bar to allow target acquisition once this OB has completed.']
-            self.slewcalOB.CommentToObserver = ''.join(comment)
-            self.example_calOB = copy.deepcopy(self.slewcalOB)
+            self.OBcache['slewcal'].CommentToObserver = ''.join(comment)
+            self.example_calOB = copy.deepcopy(self.OBcache['slewcal'])
         else:
             self.example_calOB = ObservingBlock({})
         # Load other example Cal OBs
@@ -870,7 +871,8 @@ class MainWindow(QtWidgets.QMainWindow):
         self.log.info(f"set_weather_band: {WB}")
         self.SortOrWeather.setCurrentText(WB)
         self.KPFCC_weather_band = WB
-        self.OBListModel.set_list(self.KPFCC_OBs[WB],
+        OBs_for_list = [self.OBcache[obid] for obid in self.KPFCC_OBs[WB]]
+        self.OBListModel.set_list(OBs_for_list,
                                   start_times=self.KPFCC_start_times[WB])
 
 
@@ -957,7 +959,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.KPFCC = False
                 self.clear_OB_selection()
                 self.OBListHeader.setText(self.hdr)
-                OBs = GetObservingBlocksByProgram.execute({'program': progID})
+                OBs, failures = GetObservingBlocksByProgram.execute({'program': progID})
                 msg = f"Retrieved {len(OBs)} OBs for program {progID}"
                 self.GUITaskLabel.setText(msg)
                 self.log.debug(msg)
@@ -988,7 +990,7 @@ class MainWindow(QtWidgets.QMainWindow):
         # Iterate of KPF-CC programIDs and retrieve their OBs from DB
         for i,progID in enumerate(progIDs):
             self.log.debug(f'Retrieving OBs for {progID}')
-            programOBs = GetObservingBlocksByProgram.execute({'program': progID})
+            programOBs, failures = GetObservingBlocksByProgram.execute({'program': progID})
             self.OBListModel.extend(programOBs)
             self.log.debug(f'  Got {len(programOBs)} for {progID}, total KPF-CC OB count is now {len(self.OBListModel.OBs)}')
             self.ProgressBar.setValue(int((i+1)/len(progIDs)*100))
@@ -1056,51 +1058,59 @@ class MainWindow(QtWidgets.QMainWindow):
             nOBs_this_WB = len(schedule_file_contents[WB])
             self.log.debug(f'Getting {nOBs_this_WB} OBs for weather band {WB}')
             # Pre-load a slewcal OB for convienience
-            if self.slewcalOB is not None:
-                self.KPFCC_OBs[WB] = [self.slewcalOB]
+            if self.OBcache['slewcal'] is not None:
+                self.KPFCC_OBs[WB] = ['slewcal']
                 self.KPFCC_start_times[WB] = [0]
             else:
                 self.KPFCC_OBs[WB] = []
                 self.KPFCC_start_times[WB] = []
-            for entry in schedule_file_contents[WB]:
+            for schedind,entry in enumerate(schedule_file_contents[WB]):
                 scheduledOBcount += 1
+                obid = entry[id_column_name]
                 if id_column_name not in entry.keys():
-                    errmsg = f"{entry['Target']} Failed: no id column"
+                    errmsg = f"band {WB}, line={schedind}, {entry['Target']}: Failed no id column"
                     self.log.error(errmsg)
                     errs.append(errmsg)
-                    self.GUITaskLabel.setText('\n'.join(GUImsg+errs))
-                elif entry[id_column_name] in ['', None, 'None']:
-                    errmsg = f"{entry['Target']} Failed: no id value"
+                    self.GUITaskLabel.setText('\n'.join(GUImsg))
+                elif obid in ['', None, 'None']:
+                    errmsg = f"{WB} line={schedind}, {entry['Target']}: Failed no id value"
                     self.log.error(errmsg)
                     errs.append(errmsg)
-                    self.GUITaskLabel.setText('\n'.join(GUImsg+errs))
+                    self.GUITaskLabel.setText('\n'.join(GUImsg))
                 else:
-                    result = GetObservingBlocks.execute({'OBid': entry[id_column_name]})
-                    if len(result) > 0:
-                        OB = result[0]
-                    else:
-                        OB = None
-                    if isinstance(OB, ObservingBlock):
-                        self.KPFCC_OBs[WB].append(OB)
-                        start = entry['StartExposure'].split(':')
-                        start_decimal = int(start[0]) + int(start[1])/60
+                    start = entry['StartExposure'].split(':')
+                    start_decimal = int(start[0]) + int(start[1])/60
+                    # See if we have downloaded this before
+                    if obid in self.OBcache.keys():
+                        self.log.info(f"{WB} line={schedind}, {entry['Target']}: Already downloaded")
+                        OB = self.OBcache[obid]
+                        self.KPFCC_OBs[WB].append(obid)
                         self.KPFCC_start_times[WB].append(start_decimal)
                         retrievedOBcount += 1
                     else:
-                        errmsg = f"{entry['Target']}: Failed to retrieve OB"
-                        self.log.error(errmsg)
-                        errs.append(errmsg)
+                        self.log.info(f"{WB} line={schedind}, {entry['Target']}: Downloading ...")
+                        result, failure_messages = GetObservingBlocks.execute({'OBid': obid})
+                        if len(result) > 0:
+                            self.OBcache[obid] = result[0]
+                            self.KPFCC_OBs[WB].append(obid)
+                            self.KPFCC_start_times[WB].append(start_decimal)
+                            retrievedOBcount += 1
+                        else:
+                            errs += failure_messages
                 self.ProgressBar.setValue(int(scheduledOBcount/Nsched*100))
             # Append a slewcal OB for convienience
-            if self.slewcalOB is not None:
-                self.KPFCC_OBs[WB].append(self.slewcalOB)
+            if self.OBcache['slewcal'] is not None:
+                self.KPFCC_OBs[WB].append('slewcal')
                 self.KPFCC_start_times[WB].append(24)
         msg = [f"Retrieved {retrievedOBcount} (out of {scheduledOBcount}) OBs for all weather bands"]
         self.GUITaskLabel.setText("".join(msg))
-        msg.extend(errs)
         self.set_weather_band(self.KPFCC_weather_band)
         self.refresh_history()
         self.set_SortOrWeather()
+        # Pop up for any errors
+        print(type(errs), errs)
+        if len(errs) > 0:
+            ConfirmationPopup('Errors retrieving OBs:', errs, info_only=True, warning=True).exec_()
 
     def refresh_history(self):
         self.log.debug(f"refresh_history")

--- a/kpf/OB_GUI/KPF_OB_GUI.ui
+++ b/kpf/OB_GUI/KPF_OB_GUI.ui
@@ -655,7 +655,7 @@
         <item row="8" column="0" colspan="2">
          <widget class="QLabel" name="SOB_Observation2">
           <property name="text">
-           <string> </string>
+           <string/>
           </property>
          </widget>
         </item>
@@ -739,7 +739,7 @@
         <item row="7" column="0" colspan="2">
          <widget class="QLabel" name="SOB_Observation1">
           <property name="text">
-           <string> </string>
+           <string/>
           </property>
          </widget>
         </item>
@@ -1743,6 +1743,7 @@
     <addaction name="action_LoadOBsFromFiles"/>
     <addaction name="action_LoadOBsFromProgram"/>
     <addaction name="actionLoad_KPF_CC_OBs"/>
+    <addaction name="actionLoad_Schedule_for_non_CC_Night"/>
    </widget>
    <widget class="QMenu" name="menuFile_2">
     <property name="title">
@@ -1883,6 +1884,11 @@
   <action name="actionDisable_Magiq">
    <property name="text">
     <string>Disable Magiq Star List Integration</string>
+   </property>
+  </action>
+  <action name="actionLoad_Schedule_for_non_CC_Night">
+   <property name="text">
+    <string>Load KPF-CC Schedule for a non-CC Night</string>
    </property>
   </action>
  </widget>

--- a/kpf/OB_GUI/OBListModel.py
+++ b/kpf/OB_GUI/OBListModel.py
@@ -100,7 +100,7 @@ class OBListModel(QtCore.QAbstractListModel):
                 return QtGui.QImage(f'{self.icon_path}/status-away.png')
 
     def refresh_history(self, history):
-        self.log.debug(f'refresh_history')
+        self.log.debug(f'OBListModel refresh_history: {history}')
         OBIDs = [OB.OBID for OB in self.OBs]
         refreshed = 0
         # Clear History in OBs and replace with refreshed values

--- a/kpf/ObservingBlocks/Calibration.py
+++ b/kpf/ObservingBlocks/Calibration.py
@@ -61,8 +61,8 @@ class Calibration(BaseOBComponent):
                 (self.get('ExpMeterMode') in ['off', 'False', False], ['ExpMeterMode', 'ExpMeterExpTime']),
                 (self.get('ExpMeterMode') != 'control', ['ExpMeterBin', 'ExpMeterThreshold']),
                 (self.get('TakeSimulCal') == False, ['CalND1', 'CalND2']),
-                (self.get('CalSource') != 'WideFlat', ['WideFlatPos'])
-                (self.get('WideFlatPos') != 'Blank', ['WideFlatPos'])
+                (self.get('CalSource') != 'WideFlat', ['WideFlatPos']),
+                (self.get('WideFlatPos') != 'Blank', ['WideFlatPos']),
                 ]
 
 

--- a/kpf/ObservingBlocks/Calibration.py
+++ b/kpf/ObservingBlocks/Calibration.py
@@ -58,10 +58,11 @@ class Calibration(BaseOBComponent):
 
     def get_pruning_guide(self):
         return [(self.get('CalSource').lower() in ['dark', 'home'], self.skip_if_dark),
-                (self.get('ExpMeterMode') in ['off', 'False', False], ['ExpMeterExpTime']),
+                (self.get('ExpMeterMode') in ['off', 'False', False], ['ExpMeterMode', 'ExpMeterExpTime']),
                 (self.get('ExpMeterMode') != 'control', ['ExpMeterBin', 'ExpMeterThreshold']),
                 (self.get('TakeSimulCal') == False, ['CalND1', 'CalND2']),
                 (self.get('CalSource') != 'WideFlat', ['WideFlatPos'])
+                (self.get('WideFlatPos') != 'Blank', ['WideFlatPos'])
                 ]
 
 

--- a/kpf/ObservingBlocks/exampleOBs/Calibrations.yaml
+++ b/kpf/ObservingBlocks/exampleOBs/Calibrations.yaml
@@ -1,4 +1,5 @@
 Calibrations:
+# Bias:
 - CalSource: 'Dark'
   Object: 'Bias'
   nExp: 1
@@ -6,6 +7,7 @@ Calibrations:
   TriggerCaHK: True
   TriggerGreen: True
   TriggerRed: True
+# Dark:
 - CalSource: 'Dark'
   Object: 'Dark'
   nExp: 1
@@ -28,10 +30,11 @@ Calibrations:
   OpenSkyShutter: True
   TakeSimulCal: True
   WideFlatPos: 'Blank'
+# LFC: updated 2025-10-20 (LFC flattener tuned this day as well)
 - CalSource: 'LFCFiber'
   Object: 'LFC'
   nExp: 1
-  ExpTime: 60
+  ExpTime: 10
   TriggerCaHK: False
   TriggerGreen: True
   TriggerRed: True
@@ -42,6 +45,7 @@ Calibrations:
   OpenSkyShutter: True
   TakeSimulCal: True
   WideFlatPos: 'Blank'
+# Th Daily: 
 - CalSource: 'Th_daily'
   Object: 'ThAr'
   nExp: 1
@@ -56,6 +60,7 @@ Calibrations:
   OpenSkyShutter: True
   TakeSimulCal: True
   WideFlatPos: 'Blank'
+# Th Daily (for CaHK): 
 - CalSource: 'Th_daily'
   Object: 'ThAr_forCaHK'
   nExp: 1
@@ -70,6 +75,7 @@ Calibrations:
   OpenSkyShutter: True
   TakeSimulCal: True
   WideFlatPos: 'Blank'
+# U Daily: 
 - CalSource: 'U_daily'
   Object: 'UNe'
   nExp: 1
@@ -84,16 +90,17 @@ Calibrations:
   OpenSkyShutter: True
   TakeSimulCal: True
   WideFlatPos: 'Blank'
+# Flat: updated 2025-10-20
 - CalSource: 'BrdbandFiber'
   Object: 'Flat'
   nExp: 1
-  ExpTime: 60
+  ExpTime: 240
   TriggerCaHK: False
   TriggerGreen: True
   TriggerRed: True
   IntensityMonitor: False
   CalND1: 'OD 0.1'
-  CalND2: 'OD 0.1'
+  CalND2: 'OD 1.0'
   OpenScienceShutter: True
   OpenSkyShutter: True
   TakeSimulCal: True

--- a/kpf/ObservingBlocks/exampleOBs/Calibrations.yaml
+++ b/kpf/ObservingBlocks/exampleOBs/Calibrations.yaml
@@ -9,14 +9,14 @@ Calibrations:
 - CalSource: 'Dark'
   Object: 'Dark'
   nExp: 1
-  ExpTime: 60
+  ExpTime: 1200
   TriggerCaHK: True
   TriggerGreen: True
   TriggerRed: True
 - CalSource: 'EtalonFiber'
   Object: 'Etalon'
   nExp: 1
-  ExpTime: 60
+  ExpTime: 40
   TriggerCaHK: False
   TriggerGreen: True
   TriggerRed: True
@@ -97,19 +97,3 @@ Calibrations:
   OpenSkyShutter: True
   TakeSimulCal: True
   WideFlatPos: Blank
-# - CalSource: 'SoCal-SciSky'
-#   Object: 'SoCal'
-#   nExp: 1
-#   ExpTime: 12
-#   TriggerCaHK: False
-#   TriggerGreen: True
-#   TriggerRed: True
-#   IntensityMonitor: False
-#   CalND1: 'OD 0.1'
-#   CalND2: 'OD 0.1'
-#   OpenScienceShutter: True
-#   OpenSkyShutter: True
-#   TakeSimulCal: True
-#   WideFlatPos: 'Blank'
-# WideFlat?
-# SoCal-Cal

--- a/kpf/ObservingBlocks/exampleOBs/Calibrations.yaml
+++ b/kpf/ObservingBlocks/exampleOBs/Calibrations.yaml
@@ -13,16 +13,17 @@ Calibrations:
   TriggerCaHK: True
   TriggerGreen: True
   TriggerRed: True
+# Etalon: updated 2025-10-19
 - CalSource: 'EtalonFiber'
   Object: 'Etalon'
   nExp: 1
-  ExpTime: 40
+  ExpTime: 20
   TriggerCaHK: False
   TriggerGreen: True
   TriggerRed: True
   IntensityMonitor: False
-  CalND1: 'OD 1.0'
-  CalND2: 'OD 0.1'
+  CalND1: 'OD 0.1'
+  CalND2: 'OD 1.3'
   OpenScienceShutter: True
   OpenSkyShutter: True
   TakeSimulCal: True

--- a/kpf/ObservingBlocks/exampleOBs/Calibrations.yaml
+++ b/kpf/ObservingBlocks/exampleOBs/Calibrations.yaml
@@ -30,11 +30,11 @@ Calibrations:
   OpenSkyShutter: True
   TakeSimulCal: True
   WideFlatPos: 'Blank'
-# LFC: updated 2025-10-20 (LFC flattener tuned this day as well)
+# LFC: updated 2025-10-28
 - CalSource: 'LFCFiber'
   Object: 'LFC'
   nExp: 1
-  ExpTime: 10
+  ExpTime: 60
   TriggerCaHK: False
   TriggerGreen: True
   TriggerRed: True
@@ -90,11 +90,11 @@ Calibrations:
   OpenSkyShutter: True
   TakeSimulCal: True
   WideFlatPos: 'Blank'
-# Flat: updated 2025-10-20
+# Flat: updated 2025-10-28
 - CalSource: 'BrdbandFiber'
   Object: 'Flat'
   nExp: 1
-  ExpTime: 240
+  ExpTime: 50
   TriggerCaHK: False
   TriggerGreen: True
   TriggerRed: True

--- a/kpf/calbench/PredictNDFilters.py
+++ b/kpf/calbench/PredictNDFilters.py
@@ -42,7 +42,8 @@ def all_possible_sums_with_indices_sorted(arr1, arr2):
 ## ------------------------------
 # function to derive etalon OD setting
 def get_simulcal_od(vmag, teff, exp_time, cal_fits, ref_wave=None,
-                    od_values=[0.2,1.0,1.3,2.0,3.0,4.0],
+#                     od_values=[0.2,1.0,1.3,2.0,3.0,4.0],
+                    od_values=[0.1,0.3,0.5,1.0,1.3,2.0],
                     filter_configs=[(0,0),(0,1),(0,2),(0,3),(0,4),(0,5)],
                     plot=False):
     '''

--- a/kpf/calbench/PredictNDFilters.py
+++ b/kpf/calbench/PredictNDFilters.py
@@ -267,7 +267,7 @@ class PredictNDFilters(KPFFunction):
         # reference calibration file to scale up/down
         #cal_file = 'KP.20240529.80736.43_L1.fits' # reference etalon L1 file
         data_dir = Path(__file__).parent.parent.parent / 'data'
-        cal_file = data_dir / 'KP.20250802.80643.77_L1.fits'
+        cal_file = data_dir / 'KP.20251021.78007.91_L1.fits'
 
         # Filter wheel populations for both wheels
 #         od_arr_scical = [0.1, 0.3, 0.5, 0.8, 1.0, 4.0]

--- a/kpf/calbench/SetND.py
+++ b/kpf/calbench/SetND.py
@@ -48,8 +48,8 @@ class SetND(KPFFunction):
                                      "OD 3.0", "OD 4.0"],
                             help='ND1 Filter to use.')
         parser.add_argument('CalND2', type=str,
-                            choices=["OD 0.1", "OD 0.3", "OD 0.5", "OD 0.8",
-                                     "OD 1.0", "OD 4.0"],
+                            choices=["OD 0.1", "OD 0.3", "OD 0.5", "OD 1.0",
+                                     "OD 1.3", "OD 2.0"],
                             help='ND2 Filter to use.')
         parser.add_argument("--nowait", dest="wait",
                             default=True, action="store_false",

--- a/kpf/calbench/SetND2.py
+++ b/kpf/calbench/SetND2.py
@@ -13,7 +13,7 @@ class SetND2(KPFFunction):
         CalND2 (str): The neutral density filter to put in the second filter
             wheel. This affects only the light injected in to the simultaneous
             calibration fiber. Allowed Values: `OD 0.1`, `OD 0.3`, `OD 0.5`,
-            `OD 0.8`, `OD 1.0`, `OD 4.0`
+            `OD 1.0`, `OD 1.3`, `OD 2.0`
         wait (bool): Wait for move to complete before returning? default: True
 
     KTL Keywords Used:
@@ -46,8 +46,8 @@ class SetND2(KPFFunction):
     @classmethod
     def add_cmdline_args(cls, parser):
         parser.add_argument('CalND2', type=str,
-                            choices=["OD 0.1", "OD 0.3", "OD 0.5", "OD 0.8",
-                                     "OD 1.0", "OD 4.0"],
+                            choices=["OD 0.1", "OD 0.3", "OD 0.5", "OD 1.0",
+                                     "OD 1.3", "OD 2.0"],
                             help='ND2 Filter to use.')
         parser.add_argument("--nowait", dest="wait",
                             default=True, action="store_false",

--- a/kpf/calbench/WaitForND.py
+++ b/kpf/calbench/WaitForND.py
@@ -46,6 +46,8 @@ class WaitForND(KPFFunction):
                                      "OD 3.0", "OD 4.0"],
                             help='ND1 Filter to use.')
         parser.add_argument('CalND2', type=str,
+                            choices=["OD 0.1", "OD 0.3", "OD 0.5", "OD 1.0",
+                                     "OD 1.3", "OD 2.0"],
                             help='ND2 Filter to use.')
         return super().add_cmdline_args(parser)
 

--- a/kpf/calbench/WaitForND2.py
+++ b/kpf/calbench/WaitForND2.py
@@ -14,7 +14,7 @@ class WaitForND2(KPFFunction):
         CalND2 (str): The neutral density filter to put in the first filter
             wheel. This affects only the light injected in to the simultaneous
             calibration fiber. Allowed Values: `OD 0.1`, `OD 0.3`, `OD 0.5`,
-            `OD 0.8`, `OD 1.0`, `OD 4.0`
+            `OD 1.0`, `OD 1.3`, `OD 2.0`
 
     KTL Keywords Used:
 
@@ -49,7 +49,7 @@ class WaitForND2(KPFFunction):
     @classmethod
     def add_cmdline_args(cls, parser):
         parser.add_argument('CalND2', type=str,
-                            choices=["OD 0.1", "OD 0.3", "OD 0.5", "OD 0.8",
-                                     "OD 1.0", "OD 4.0"],
+                            choices=["OD 0.1", "OD 0.3", "OD 0.5", "OD 1.0",
+                                     "OD 1.3", "OD 2.0"],
                             help='ND2 Filter to use.')
         return super().add_cmdline_args(parser)

--- a/kpf/cli_interface.py
+++ b/kpf/cli_interface.py
@@ -333,5 +333,5 @@ def main(table_loc, parsed_args, function_args, kpfdo_parser):
             result = function.execute(parsed_func_args, OB=OB)
         else:
             result = function.execute(parsed_func_args)
-        if result is not None:
-            print(result)
+#         if result is not None:
+#             print(result)

--- a/kpf/engineering/plot_ffts.py
+++ b/kpf/engineering/plot_ffts.py
@@ -1,0 +1,152 @@
+#!python3
+
+## Import General Tools
+from pathlib import Path
+import argparse
+import datetime
+import re
+
+import numpy as np
+import matplotlib.pylab as plt
+
+from scipy.fft import fft
+import scipy
+import scipy.stats
+
+
+##-------------------------------------------------------------------------
+## Parse Command Line Arguments
+##-------------------------------------------------------------------------
+## create a parser object for understanding command-line arguments
+p = argparse.ArgumentParser(description='''Overlay the power spectrum of the
+detector noise from the "horizontal raw plot" data from ArchonGUI. If multiple
+input files are provided they will be over plotted on one another.
+
+This was designed to work on the FITS files produced by archonGUI (see
+https://keckobservatory.atlassian.net/wiki/x/AYAnk) and is not tested on files
+from the main KPF data taking system (e.g. the KTL keywords). The file names
+are assumed to match a particular pattern:
+* start with either G or R to indicate whether it is the green or red side
+* include a description in the middle offset by underscores (`_`).
+* include pixel dimension (e.g. `_4188x4110`, the default from ArchonGUI).
+* end in the frame number (again the default from ArchonGUI)
+''')
+## add arguments
+p.add_argument('files', nargs='*',
+               help="The files to process")
+## add options
+p.add_argument("-m", "--marker", dest="marker", type=float,
+    help="Put a marker at this frequency (in kHz).")
+p.add_argument("-o", "--outfile", dest="outfile", type=str, default='FFTs.png',
+    help="The output file name (defaults to FFTs.png).")
+args = p.parse_args()
+
+
+
+def load_archon_video(filename='Aug11_regulargreen/2025aug11/6070.csv',maxrows=2560000):
+    """ 
+    loads voltage data and creates time array in nanoseconds
+    archon samples video signal at 10ns per step or 100MHz
+    """
+    x,y = np.loadtxt(filename,skiprows=1,max_rows=maxrows).T
+    # step size for archon is 
+    tstep = 10 # 10 nano seconds or 100MHz
+    return x*tstep, y
+
+
+def extract_pixel_data(xs, ys, iref, ipix, pixel_time=4980,gain=5):
+    """
+    average reference region and pixel region for each pixel
+
+    returns the final pixel data and N, which should be the number of pixels
+
+    default is gain of 5 and pixel time of 4980ns (regular read mode)
+    """
+    ref_data  = []
+    pix_data  = []
+    ref_noise = []
+    pix_noise = []
+    N=0
+    while pixel_time * N < xs[-1]:
+        ref_data.append(np.nanmean(ys[(pixel_time*N +iref[0])//10: (pixel_time*N +iref[1])//10]))
+        pix_data.append(np.nanmean(ys[(pixel_time*N +ipix[0])//10: (pixel_time*N +ipix[1])//10]))
+        ref_noise.append(np.nanstd(ys[(pixel_time*N +iref[0])//10: (pixel_time*N +iref[1])//10]))
+        pix_noise.append(np.nanstd(ys[(pixel_time*N +ipix[0])//10: (pixel_time*N +ipix[1])//10]))
+        N+=1
+
+    final_data = np.array(ref_data) - np.array(pix_data)
+#     print('%s pixels read' %N)
+
+    return gain * final_data, ref_noise, pix_noise
+
+
+def do_fft(x,y):
+    """run FFT of x and y data, x in seconds gives freq in hz"""
+    X = fft(y)
+    sampling_time = np.mean(np.diff(x))
+    freq = scipy.fft.fftfreq(len(X), sampling_time)
+    
+    return np.abs(freq), np.abs(X)
+
+
+##-------------------------------------------------------------------------
+## Main Program
+##-------------------------------------------------------------------------
+def main():
+    # Parse files
+    fileinfo = {}
+    for file in args.files:
+        fnmatch = re.match('([GR])[a-zA-Z]*_(.*)_4188x4110_(\d+)\.(\w+)', Path(file).name)
+        if fnmatch:
+            timestamp = datetime.datetime.fromtimestamp(Path(file).stat().st_mtime)
+            fileinfo[file] = {'det': fnmatch.group(1),
+                              'label': fnmatch.group(2),
+                              'frameno': int(fnmatch.group(3)),
+                              'ext': fnmatch.group(4),
+                              'timestamp': timestamp,
+                              'timestr': timestamp.strftime('%Y-%m-%d %H:%M:%S'),
+                              }
+        else:
+            print(f'Failed to parse filename: {Path(file).name}')
+
+
+    pixel_time = 4980         # nanoseconds,  should be 2520 nanoseconds for fast read mode
+    iref = np.array([530,2120])+2120     # tuning of these regions are not critical when clocks are off
+    ipix = np.array([3300,5000])+2120    # these were tuned on clock data
+
+    txtfiles = [file for file in fileinfo.keys() if fileinfo[file]['ext'] == 'txt']
+
+    num_colors = len(txtfiles)
+    colors = ['r', 'g', 'b', 'c', 'm', 'y', 'k']
+
+    plt.figure(figsize=(12,8))
+    for i,file in enumerate(txtfiles):
+        print(f'Getting FFT of {file}')
+        xs, ys = load_archon_video(filename=file, maxrows=737000)
+        alldata, pix_data, ref_data = extract_pixel_data(xs, ys, iref, ipix, pixel_time=pixel_time)
+        allnoise = np.std(alldata[200:1153])#[14:146]) # exclude the spike from parallel read out
+        xf, yfft  =  do_fft(xs[100000:]*1e-9, ys[100000:])
+        label = f"{fileinfo[file]['det']} {fileinfo[file]['frameno']}: {fileinfo[file]['label']}"
+        multiplier = 1#e3**i
+        plt.loglog(xf, yfft*multiplier, f'{colors[i]}-', alpha=0.25)
+        # Bin data and plot mean in each bin
+        means, bins, binnumber = scipy.stats.binned_statistic(xf, yfft, statistic='mean', bins=10000)
+        plt.loglog(bins[1:], means*multiplier, f'{colors[i]}-', alpha=0.75,
+                   drawstyle='steps-pre', label=label)
+    if args.marker:
+        freq = args.marker*1e3
+        plt.axvline(x=freq, color='b', linestyle=':', ymin=0.1, ymax=0.9, alpha=0.5,
+                    label=f'{args.marker:,.0f} kHz')
+
+    plt.title('FFT of Video Signals')
+    plt.legend()
+    plt.xlabel("Freq (Hz)")
+    plt.xlim(1e4,5e7)
+    plt.ylabel('Amplitude')
+    plt.grid()
+    plt.savefig(args.outfile, bbox_inches='tight', pad_inches=0.1)
+
+
+
+if __name__ == '__main__':
+    main()

--- a/kpf/engineering/plot_read_noise.py
+++ b/kpf/engineering/plot_read_noise.py
@@ -1,0 +1,118 @@
+#!python3
+
+## Import General Tools
+from pathlib import Path
+import argparse
+import datetime
+import re
+
+import numpy as np
+from astropy.io import fits
+import matplotlib.pylab as plt
+
+
+##-------------------------------------------------------------------------
+## Parse Command Line Arguments
+##-------------------------------------------------------------------------
+## create a parser object for understanding command-line arguments
+p = argparse.ArgumentParser(description='''Plot the read noise over time from
+the input FITS files.
+
+This was designed to work on the FITS files produced by archonGUI (see
+https://keckobservatory.atlassian.net/wiki/x/AYAnk) and is not tested on files
+from the main KPF data taking system (e.g. the KTL keywords). The file names
+are assumed to match a particular pattern:
+* start with either G or R to indicate whether it is the green or red side
+* include a description in the middle offset by underscores (`_`).
+* include pixel dimension (e.g. `_4188x4110`, the default from ArchonGUI).
+* end in the frame number (again the default from ArchonGUI)
+''')
+p.add_argument('files', nargs='*',
+               help="The files to process")
+args = p.parse_args()
+
+
+##-------------------------------------------------------------------------
+## Main Program
+##-------------------------------------------------------------------------
+def main():
+    # Parse files
+    fileinfo = {}
+    for file in args.files:
+        fnmatch = re.match('([GR])[a-zA-Z]*_(.*)_4188x4110_(\d+)\.(\w+)', Path(file).name)
+        if fnmatch:
+            timestamp = datetime.datetime.fromtimestamp(Path(file).stat().st_mtime)
+            fileinfo[file] = {'det': fnmatch.group(1),
+                              'label': fnmatch.group(2),
+                              'frameno': int(fnmatch.group(3)),
+                              'ext': fnmatch.group(4),
+                              'timestamp': timestamp,
+                              'timestr': timestamp.strftime('%Y-%m-%d %H:%M:%S'),
+                              }
+        else:
+            print(f'Failed to parse filename: {Path(file).name}')
+
+    # Iterate over FITS files and calculate read noise
+    for file in fileinfo.keys():
+        if fileinfo[file]['ext'] == 'fits':
+            hdul = fits.open(file)
+            gain = 5     # approx 5 to convert to electrons, good enough for this analysis
+            image = gain * hdul[0].data/(2**16) #convert to e-
+            # measure read noise
+            fileinfo[file]['rn_e'] = np.std(image[4:1004,4:1004].flatten())
+            fileinfo[file]['rn_oscan'] = np.std(image[:,4:5].flatten())
+
+    sortedfiles = sorted(fileinfo, key=lambda file: fileinfo[file]['timestamp'])
+    greenfiles = [file for file in sortedfiles if fileinfo[file]['det'] == 'G' and fileinfo[file]['ext'] == 'fits']
+    redfiles = [file for file in sortedfiles if fileinfo[file]['det'] == 'R' and fileinfo[file]['ext'] == 'fits']
+
+    # Plot read noise from FITS files
+    plt.figure(figsize=(12,8))
+
+    print('# Green Noise Measurements')
+    G_offset = 0.5
+    plt.subplot(2,1,1)
+    G_RN = [fileinfo[file]['rn_e'] for file in greenfiles]
+    G_RNos = [fileinfo[file]['rn_oscan'] for file in greenfiles]
+    G_timestamp = [fileinfo[file]['timestamp'] for file in greenfiles]
+    G_label = [fileinfo[file]['label'] for file in greenfiles]
+    G_frameno = [fileinfo[file]['frameno'] for file in greenfiles]
+    plt.plot(G_RN, 'go')
+    plt.plot(G_RNos, 'go', alpha=0.5)
+    for i,file in enumerate(greenfiles):
+        print(f"{fileinfo[file]['timestr']} {file:50s}: {fileinfo[file]['rn_e']:5.2f} {fileinfo[file]['rn_oscan']:5.2f}")
+        plt.text(i, max([fileinfo[file]['rn_e'], fileinfo[file]['rn_e']])+G_offset, G_label[i],
+                 rotation='vertical')
+    plt.ylabel('Read Noise (e-)')
+#     plt.ylim(min(G_RN)*0.98, max(G_RN)*1.05)
+    plt.ylim(3.5, max(G_RN)+3)
+    plt.xticks(range(len(G_frameno)), G_frameno)
+    plt.grid()
+
+    print('# Red Noise Measurements')
+    R_offset = 0.1
+    plt.subplot(2,1,2)
+    R_RN = [fileinfo[file]['rn_e'] for file in redfiles]
+    R_RNos = [fileinfo[file]['rn_oscan'] for file in redfiles]
+    R_timestamp = [fileinfo[file]['timestamp'] for file in redfiles]
+    R_label = [fileinfo[file]['label'] for file in redfiles]
+    R_frameno = [fileinfo[file]['frameno'] for file in redfiles]
+    plt.plot(R_RN, 'ro')
+    plt.plot(R_RNos, 'ro', alpha=0.5)
+    for i,file in enumerate(redfiles):
+        print(f"{fileinfo[file]['timestr']} {file:50s}: {fileinfo[file]['rn_e']:5.2f} {fileinfo[file]['rn_oscan']:5.2f}")
+        plt.text(i, fileinfo[file]['rn_e']+R_offset, R_label[i],
+                 rotation='vertical')
+    plt.ylabel('Read Noise (e-)')
+#     plt.ylim(min(R_RN)*0.98, max(R_RN)*1.05)
+    plt.ylim(1.5, max(R_RN)+1)
+    plt.xlabel('Frame Number')
+    plt.xticks(range(len(R_frameno)), R_frameno)
+    plt.grid()
+
+    plt.savefig('ReadNoise.png', bbox_inches='tight', pad_inches=0.1)
+    plt.show()
+
+
+if __name__ == '__main__':
+    main()

--- a/kpf/guider/GuiderLastfile.py
+++ b/kpf/guider/GuiderLastfile.py
@@ -31,6 +31,7 @@ class GuiderLastfile(KPFFunction):
             expr = f"($kpfguide.LASTFILE != '{initial_lastfile}')"
             ktl.waitFor(expr, timeout=exptime+timeout)
         lastfile = kpfguide['LASTFILE'].read()
+        print(lastfile)
         return lastfile
 
     @classmethod

--- a/kpf/guider/GuiderOutdir.py
+++ b/kpf/guider/GuiderOutdir.py
@@ -21,7 +21,9 @@ class GuiderOutdir(KPFFunction):
     @classmethod
     def perform(cls, args):
         OUTDIR = ktl.cache('kpfguide', 'OUTDIR')
-        return OUTDIR.read()
+        OUTDIR.monitor()
+        print(OUTDIR.ascii)
+        return OUTDIR.ascii
 
     @classmethod
     def post_condition(cls, args):

--- a/kpf/guider/TakeGuiderCube.py
+++ b/kpf/guider/TakeGuiderCube.py
@@ -64,7 +64,7 @@ class TakeGuiderCube(KPFFunction):
         # Reset ALL_LOOPS to initial values
 #         if initial_all_loops == 'Active' and collect_image_cube == True:
 #             kpfguide['ALL_LOOPS'].write(initial_all_loops)
-
+        print(cube_file)
         return cube_file
 
     @classmethod

--- a/kpf/kpf_inst_config.ini
+++ b/kpf/kpf_inst_config.ini
@@ -94,7 +94,7 @@ red_fast = fast-read-red
 enclosure_status_time = 10
 pyrirrad_threshold = 900
 park_time = 300
-SoCalOB = /s/sdata1701/OBs/jwalawender/Calibrations/SoCal.yaml
+SoCalOB = /kroot/rel/default/data/obs/kpf/SoCal.yaml
 
 [ObservatoryAPIs]
 proposal_url = https://vm-appserver.keck.hawaii.edu/api/proposals/

--- a/kpf/linking_table.yml
+++ b/kpf/linking_table.yml
@@ -323,6 +323,8 @@ links:
     EastNorth:
         cmd: telescope.EastNorth.EastNorth
     # Utils
+    BuildCalOB:
+        cmd: utils.BuildCalOB.BuildCalOB
     CheckAllowScheduledCals:
         cmd: utils.CheckAllowScheduledCals.CheckAllowScheduledCals
     EndOfNight:

--- a/kpf/linking_table.yml
+++ b/kpf/linking_table.yml
@@ -214,6 +214,8 @@ links:
     SetTargetList:
         cmd: magiq.SetTargetList.SetTargetList
     # Observatory APIs
+    GetCurrentScheduledProgram:
+        cmd: observatoryAPIs.GetCurrentScheduledProgram.GetCurrentScheduledProgram
     GetExecutionHistory:
         cmd: observatoryAPIs.GetExecutionHistory.GetExecutionHistory
     GetKPFCCObservingBlocks:

--- a/kpf/observatoryAPIs/GetCurrentScheduledProgram.py
+++ b/kpf/observatoryAPIs/GetCurrentScheduledProgram.py
@@ -1,0 +1,57 @@
+import datetime
+
+from kpf import log, cfg
+from kpf.exceptions import *
+from kpf.KPFTranslatorFunction import KPFFunction, KPFScript
+from kpf.observatoryAPIs import get_semester_dates, query_observatoryAPI
+
+
+def string_time_to_decimal(time_str):
+    h = int(time_str.split(':')[0])
+    m = int(time_str.split(':')[1])
+    return h + m/60
+
+
+class GetCurrentScheduledProgram(KPFFunction):
+    '''
+
+    '''
+    @classmethod
+    def pre_condition(cls, args):
+        pass
+
+    @classmethod
+    def perform(cls, args):
+        '''Returns the currently scheduled program ID.
+        '''
+        if args.get('datetime', 'now') == 'now':
+            inputdateUT = datetime.datetime.utcnow()
+        else:
+            inputdateHST = datetime.datetime.strptime(args.get('datetime'), '%Y-%m-%dT%H:%M:%S')
+            inputdateUT = inputdateHST + datetime.timedelta(hours=10)
+        startdate = inputdateUT - datetime.timedelta(days=1)
+        UTdecimal_hour = inputdateUT.hour + inputdateUT.minute/60
+
+        params = {'date': startdate.strftime('%Y-%m-%d'),
+                  'numdays': 1,
+                  'telnr': args.get('telnr', 1),
+                  'instrument': 'KPF'}
+        all_programs = query_observatoryAPI('schedule', 'getSchedule', params)
+
+        progname = None
+        for program in all_programs:
+            prog_start = string_time_to_decimal(program.get('StartTime'))
+            prog_end = string_time_to_decimal(program.get('EndTime'))
+            if UTdecimal_hour >= prog_start and UTdecimal_hour <= prog_end:
+                progname = program.get('ProjCode')
+        return progname
+
+    @classmethod
+    def post_condition(cls, args):
+        pass
+
+    @classmethod
+    def add_cmdline_args(cls, parser):
+        parser.add_argument('datetime', type=str, default='now',
+            help='The HST date and time to retrieve (%Y-%m-%dT%H:%M:%S).')
+        return super().add_cmdline_args(parser)

--- a/kpf/observatoryAPIs/GetKPFCCObservingBlocks.py
+++ b/kpf/observatoryAPIs/GetKPFCCObservingBlocks.py
@@ -34,7 +34,7 @@ class GetKPFCCObservingBlocks(KPFFunction):
         # Iterate of KPF-CC programIDs and retrieve their OBs from DB
         for i,progID in enumerate(progIDs):
             log.debug(f'Retrieving OBs for {progID}')
-            programOBs = GetObservingBlocksByProgram.execute({'program': progID})
+            programOBs, failures = GetObservingBlocksByProgram.execute({'program': progID})
             OBs.extend(programOBs)
         log.info(f'Retrieved {len(OBs)} OBs in KPF-CC programs')
         # Save to files if requested

--- a/kpf/observatoryAPIs/GetObservingBlocks.py
+++ b/kpf/observatoryAPIs/GetObservingBlocks.py
@@ -19,7 +19,7 @@ class GetObservingBlocks(KPFFunction):
     @classmethod
     def perform(cls, args):
         params = {'id': args.get('OBid', '')}
-        OBs = get_OBs_from_KPFCC_API(params)
+        OBs, failure_messages = get_OBs_from_KPFCC_API(params)
         if args.get('show_history', False):
             print(f'# Observing History for {OBs[0].summary()}')
             for i,h in enumerate(OBs[0].History):
@@ -33,7 +33,10 @@ class GetObservingBlocks(KPFFunction):
                 comment = h.get('comment', '')
                 if len(comment) > 0:
                     print(f"  Observer comment: {comment}")
-        return OBs
+        if len(failure_messages) > 0:
+            for msg in failure_messages:
+                print(msg)
+        return OBs, failure_messages
 
     @classmethod
     def post_condition(cls, args):

--- a/kpf/observatoryAPIs/GetObservingBlocksByProgram.py
+++ b/kpf/observatoryAPIs/GetObservingBlocksByProgram.py
@@ -29,8 +29,8 @@ class GetObservingBlocksByProgram(KPFFunction):
         if program is None:
             return
         params = {'semid': f"{semester}_{program}"}
-        OBs = get_OBs_from_KPFCC_API(params)
-        return OBs
+        OBs, failure_messages = get_OBs_from_KPFCC_API(params)
+        return OBs, failure_messages
 
     @classmethod
     def post_condition(cls, args):

--- a/kpf/observatoryAPIs/__init__.py
+++ b/kpf/observatoryAPIs/__init__.py
@@ -142,7 +142,6 @@ def get_OBs_from_KPFCC_API(params):
         return []
     OBs = []
     failures = []
-    invalid = []
     n = len(result)
     for i,entry in enumerate(result):
         log.debug(f'Parsing entry {i+1} of {n}')
@@ -162,14 +161,19 @@ def get_OBs_from_KPFCC_API(params):
 #                     log.error(f'Unable to parse entry {i+1} in to an ObservingBlock')
 #                     log.error(entry)
 #                     log.error(f'{e}')
-                    failures.append([OBid, f'{e}'])
+                    semid = entry.get('semid', '')
+                    failmsg = f"{OBid} ({semid}): {e}"
+                    failures.append(failmsg)
+                    print(entry)
                 else:
                     if OB.validate():
 #                         log.debug(f'OB {i+1} is valid')
                         OBs.append(OB)
                     else:
 #                         log.debug(f'OB {i+1} is invalid')
-                        invalid.append([OBid, entry, OB])
+                        semid = entry.get('semid', '')
+                        failmsg = f"{OBid} ({semid}): Failed validataion"
+                        failures.append(failmsg)
 #                         if OB.Target is not None:
 #                             for line in OB.Target.to_lines(comment=True):
 #                                 if line.find('ERR') >= 0:
@@ -178,12 +182,6 @@ def get_OBs_from_KPFCC_API(params):
 #                             for line in obs.to_lines(comment=True):
 #                                 if line.find('ERR') >= 0:
 #                                     log.warning(line)
-    log.info(f'API returned {len(result)} entries')
-    log.info(f'  Parsed {len(OBs)} OBs from those entries')
-    for failure in failures:
-        log.error(f"  OB {failure[0]} failed: {failure[1]}")
-    for badOB in invalid:
-        log.error(f"  OB {badOB[0]} is invalid")
-        print(badOB[1])
-        print(badOB[2].validate(verbose=True))
-    return OBs
+    log.debug(f'API returned {len(result)} entries')
+    log.debug(f'  Parsed {len(OBs)} OBs from those entries')
+    return OBs, failures

--- a/kpf/scripts/EstimateOBDuration.py
+++ b/kpf/scripts/EstimateOBDuration.py
@@ -54,7 +54,7 @@ def estimate_calibration_time(calibrations, cfg, fast=False):
                                   fallback=1800)
             if duration < warm_up:
                 warm_up_wait = warm_up-duration
-                print(f"  {lamp} warm up {warm_up_wait/60:.0f} min")
+                print(f"# {lamp} warm up {warm_up_wait/60:.0f} min")
                 duration += warm_up_wait
             lamps_that_need_warmup.pop(lamps_that_need_warmup.index(lamp))
         duration += int(cal.get('nExp'))*(float(cal.get('ExpTime'))+readout)
@@ -76,7 +76,6 @@ def estimate_observation_time(observations, cfg, fast=False):
     # Execute Observations
     for obs in observations:
         duration += obs.get('nExp')*(obs.get('ExpTime')+readout)
-
     return duration
 
 
@@ -115,7 +114,11 @@ class EstimateOBDuration(KPFScript):
         if OB.Observations is not None:
             duration += estimate_observation_time(OB.Observations, cfg, fast=fast)
 
-#         print(f"{duration/60:.0f} min")
+        if args.get('verbose', False):
+            decimal_minutes = duration / 60
+            hours = int(np.floor(decimal_minutes / 60))
+            minutes = int(np.ceil(decimal_minutes % 60))
+            print(f"# Estimated Duration = {hours:02d}:{minutes:02d}")
         return duration/60
 
     @classmethod
@@ -128,6 +131,9 @@ class EstimateOBDuration(KPFScript):
                             dest="fast",
                             default=False, action="store_true",
                             help='Use fast readout mode times for estimate?')
+        parser.add_argument('-v', '--verbose', dest="verbose",
+            default=False, action="store_true",
+            help='Be verbose and print to screen?')
         return super().add_cmdline_args(parser)
 
 

--- a/kpf/scripts/ExecuteCal.py
+++ b/kpf/scripts/ExecuteCal.py
@@ -303,7 +303,7 @@ class ExecuteCal(KPFFunction):
         nexp = int(calibration.get('nExp', 1))
         exptime = float(calibration.get('ExpTime'))
         # If we are in fast read mode, turn on agitator once
-        if runagitator and fast_read_mode:
+        if runagitator and fast_read_mode and calsource.lower() != 'dark':
             StartAgitator.execute({})
         # Loop over exposures
         for j in range(nexp):
@@ -322,7 +322,7 @@ class ExecuteCal(KPFFunction):
                     SetLFCtoStandbyHigh.execute({})
                     return
             # Start agitator for each exposure if we are in normal read mode
-            if runagitator and not fast_read_mode:
+            if runagitator and not fast_read_mode and calsource.lower() != 'dark':
                 StartAgitator.execute({})
             # Set triggered detectors. This is here to force a check of the
             # ENABLED status for each detector.

--- a/kpf/scripts/ExecuteCal.py
+++ b/kpf/scripts/ExecuteCal.py
@@ -270,7 +270,7 @@ class ExecuteCal(KPFFunction):
         log.info(f"Set Detector List")
         SetTriggeredDetectors.execute(calibration)
         # Source Select Shutters
-        if calsource == 'dark':
+        if calsource.lower() == 'dark':
             SetSourceSelectShutters.execute({})
         else:
             if calsource in ['SoCal-SciSky']:

--- a/kpf/scripts/RunOB.py
+++ b/kpf/scripts/RunOB.py
@@ -26,6 +26,7 @@ from kpf.scripts.ExecuteSci import ExecuteSci
 from kpf.scripts.CleanupAfterScience import CleanupAfterScience
 from kpf.spectrograph.SetProgram import SetProgram
 from kpf.observatoryAPIs import addObservingBlockHistory
+from kpf.observatoryAPIs.GetCurrentScheduledProgram import GetCurrentScheduledProgram
 
 
 class RunOB(KPFScript):
@@ -254,7 +255,13 @@ class RunOB(KPFScript):
                     observation_dict = observation.to_dict()
                     observation_dict['Gmag'] = OB.Target.get('Gmag')
                     ConfigureForScience.execute(observation_dict)
-                    if OB.ProgramID != '':
+                    if OB.ProgramID in ['', 'None', None]:
+                        progname = GetCurrentScheduledProgram.execute({})
+                        if progname is not None:
+                            SetProgram.execute({'progname': progname})
+                        else:
+                            SetProgram.execute({'progname': 'ENG'})
+                    else:
                         SetProgram.execute({'progname': OB.ProgramID})
                     WaitForConfigureScience.execute(observation_dict)
                 except ScriptStopTriggered as scriptstop:

--- a/kpf/socal/IsSoCalShutDown.py
+++ b/kpf/socal/IsSoCalShutDown.py
@@ -30,12 +30,14 @@ class IsSoCalShutDown(KPFFunction):
 
         closedstr = {True: '', False: 'NOT '}[is_closed]
         parkedstr = {True: '', False: 'NOT '}[is_home]
-        msg = f'SoCal is {closedstr}closed and {parkedstr}parked'
+        msg = f'SoCal is {closedstr}closed and is {parkedstr}parked'
         print(msg)
 
         shutdown = is_closed and is_home
         if not shutdown and args.get('email', False) is True:
             try:
+                url = 'http://192.168.78.70/camera/index.html#/video'
+                msg += '\n\nSoCal status can be viewed using this camera: {url}'
                 SendEmail.execute({'Subject': f'KPF SoCal is not shut down properly',
                                    'Message': msg})
             except Exception as email_err:

--- a/kpf/socal/IsSoCalShutDown.py
+++ b/kpf/socal/IsSoCalShutDown.py
@@ -37,7 +37,7 @@ class IsSoCalShutDown(KPFFunction):
         if not shutdown and args.get('email', False) is True:
             try:
                 url = 'http://192.168.78.70/camera/index.html#/video'
-                msg += '\n\nSoCal status can be viewed using this camera: {url}'
+                msg += f'\n\nSoCal status can be viewed using this camera: {url}'
                 SendEmail.execute({'Subject': f'KPF SoCal is not shut down properly',
                                    'Message': msg})
             except Exception as email_err:

--- a/kpf/spectrograph/QueryReadMode.py
+++ b/kpf/spectrograph/QueryReadMode.py
@@ -33,7 +33,7 @@ class QueryReadMode(KPFFunction):
             elif filename == fast_file:
                 modes[side] = 'fast'
             else:
-                green_mode = 'unknown'
+                modes[side] = 'unknown'
 
         log.debug(f"Green read mode: {modes['green']}, Red read mode: {modes['red']}")
         print(f"Green read mode: {modes['green']}")

--- a/kpf/spectrograph/SetReadModeFast.py
+++ b/kpf/spectrograph/SetReadModeFast.py
@@ -36,32 +36,30 @@ class SetReadModeFast(KPFFunction):
             msg = f'Setting Green CCD read mode fast'
             log.info(msg)
             # Email to kpf_info
-            try:
-                SendEmail.execute({'Subject': msg, 'Message': msg})
-            except Exception as email_err:
-                log.error(f'Sending email failed')
-                log.error(email_err)
-            kpfgreen = ktl.cache('kpfgreen')
-            green_fast_file = cfg.get('acf_files', 'green_fast')
-            green_ACFFILE = Path(kpfgreen['ACFFILE'].read()).stem
-            if green_ACFFILE != green_fast_file:
-                kpfgreen['ACF'].write(green_fast_file)
-            time.sleep(1)
+#             try:
+#                 SendEmail.execute({'Subject': msg, 'Message': msg})
+#             except Exception as email_err:
+#                 log.error(f'Sending email failed')
+#                 log.error(email_err)
+#             kpfgreen = ktl.cache('kpfgreen')
+#             green_fast_file = cfg.get('acf_files', 'green_fast')
+#             green_ACFFILE = Path(kpfgreen['ACFFILE'].read()).stem
+#             if green_ACFFILE != green_fast_file:
+#                 kpfgreen['ACF'].write(green_fast_file)
         if red_mode != 'fast':
             msg = f'Setting Red CCD read mode fast'
             log.info(msg)
             # Email to kpf_info
-            try:
-                SendEmail.execute({'Subject': msg, 'Message': msg})
-            except Exception as email_err:
-                log.error(f'Sending email failed')
-                log.error(email_err)
-            kpfred = ktl.cache('kpfred')
-            red_fast_file = cfg.get('acf_files', 'red_fast')
-            red_ACFFILE = Path(kpfred['ACFFILE'].read()).stem
-            if red_ACFFILE != red_fast_file:
-                kpfred['ACF'].write(red_fast_file)
-            time.sleep(1)
+#             try:
+#                 SendEmail.execute({'Subject': msg, 'Message': msg})
+#             except Exception as email_err:
+#                 log.error(f'Sending email failed')
+#                 log.error(email_err)
+#             kpfred = ktl.cache('kpfred')
+#             red_fast_file = cfg.get('acf_files', 'red_fast')
+#             red_ACFFILE = Path(kpfred['ACFFILE'].read()).stem
+#             if red_ACFFILE != red_fast_file:
+#                 kpfred['ACF'].write(red_fast_file)
 
     @classmethod
     def post_condition(cls, args):

--- a/kpf/utils/BuildCalOB.py
+++ b/kpf/utils/BuildCalOB.py
@@ -4,6 +4,7 @@ import copy
 from kpf.exceptions import *
 from kpf.KPFTranslatorFunction import KPFFunction, KPFScript
 from kpf.ObservingBlocks.ObservingBlock import ObservingBlock
+from kpf.scripts.EstimateOBDuration import EstimateOBDuration
 
 
 ##-------------------------------------------------------------------------
@@ -55,8 +56,12 @@ class BuildCalOB(KPFFunction):
                         else:
                             cal.set(key, value)
                 OB.Calibrations.append(cal)
-        print(OB.__repr__())
 
+        if args.get('estimate', False):
+            EstimateOBDuration.execute({}, OB=OB)
+
+        if args.get('save', '') != '':
+            OB.write_to(args.get('save'), overwrite=args.get('overwrite', False))
 
     @classmethod
     def post_condition(cls, argsKPFFunction):
@@ -66,4 +71,12 @@ class BuildCalOB(KPFFunction):
     def add_cmdline_args(cls, parser):
         parser.add_argument('calinputs', nargs='*',
                             help="Calibrations to take in the form ")
+        parser.add_argument("-t", "--time", "--estimate", dest="estimate",
+                            default=False, action="store_true",
+                            help="Estimate the execution time for this OB?")
+        parser.add_argument("-s", "--save", dest="save", type=str, default='',
+                            help="Save resulting OB to the specified file.")
+        parser.add_argument("-o", "--overwrite", dest="overwrite",
+                            default=False, action="store_true",
+                            help="Overwrite output file if it exists?")
         return super().add_cmdline_args(parser)

--- a/kpf/utils/BuildCalOB.py
+++ b/kpf/utils/BuildCalOB.py
@@ -61,8 +61,9 @@ class BuildCalOB(KPFFunction):
             OB.write_to(args.get('save'), overwrite=args.get('overwrite', False))
 
         if args.get('estimate', False):
-            duration = EstimateOBDuration.execute({}, OB=OB)
-            return duration
+            duration = EstimateOBDuration.execute({'verbose': True}, OB=OB)
+
+        return OB
 
     @classmethod
     def post_condition(cls, argsKPFFunction):

--- a/kpf/utils/BuildCalOB.py
+++ b/kpf/utils/BuildCalOB.py
@@ -5,6 +5,7 @@ from kpf.exceptions import *
 from kpf.KPFTranslatorFunction import KPFFunction, KPFScript
 from kpf.ObservingBlocks.ObservingBlock import ObservingBlock
 from kpf.scripts.EstimateOBDuration import EstimateOBDuration
+from kpf.scripts.RunOB import RunOB
 
 
 ##-------------------------------------------------------------------------
@@ -60,11 +61,13 @@ class BuildCalOB(KPFFunction):
         if args.get('save', '') != '':
             OB.write_to(args.get('save'), overwrite=args.get('overwrite', False))
 
-        if args.get('estimate', False):
+        if args.get('estimate', False) or args.get('execute', False):
             cal_strings = [str(cal) for cal in OB.Calibrations]
             cal_string = ','.join(cal_strings)
             print(f"# {cal_string}")
             duration = EstimateOBDuration.execute({'verbose': True}, OB=OB)
+        if args.get('execute', False):
+            RunOB.execute({}, OB=OB)
 
         return OB
 
@@ -84,4 +87,8 @@ class BuildCalOB(KPFFunction):
         parser.add_argument("-o", "--overwrite", dest="overwrite",
                             default=False, action="store_true",
                             help="Overwrite output file if it exists?")
+        parser.add_argument("--execute", dest="execute",
+                            default=False, action="store_true",
+                            help="Execute the resulting OB?")
+
         return super().add_cmdline_args(parser)

--- a/kpf/utils/BuildCalOB.py
+++ b/kpf/utils/BuildCalOB.py
@@ -58,7 +58,7 @@ class BuildCalOB(KPFFunction):
                             cal.set(key, value)
                 OB.Calibrations.append(cal)
 
-        if args.get('save', '') != '':
+        if args.get('save', '') not in ['', None]:
             OB.write_to(args.get('save'), overwrite=args.get('overwrite', False))
 
         if args.get('estimate', False) or args.get('execute', False):
@@ -72,7 +72,7 @@ class BuildCalOB(KPFFunction):
         return OB
 
     @classmethod
-    def post_condition(cls, argsKPFFunction):
+    def post_condition(cls, args):
         pass
 
     @classmethod
@@ -90,5 +90,4 @@ class BuildCalOB(KPFFunction):
         parser.add_argument("--execute", dest="execute",
                             default=False, action="store_true",
                             help="Execute the resulting OB?")
-
         return super().add_cmdline_args(parser)

--- a/kpf/utils/BuildCalOB.py
+++ b/kpf/utils/BuildCalOB.py
@@ -61,6 +61,9 @@ class BuildCalOB(KPFFunction):
             OB.write_to(args.get('save'), overwrite=args.get('overwrite', False))
 
         if args.get('estimate', False):
+            cal_strings = [str(cal) for cal in OB.Calibrations]
+            cal_string = ','.join(cal_strings)
+            print(f"# {cal_string}")
             duration = EstimateOBDuration.execute({'verbose': True}, OB=OB)
 
         return OB
@@ -73,7 +76,7 @@ class BuildCalOB(KPFFunction):
     def add_cmdline_args(cls, parser):
         parser.add_argument('calinputs', nargs='*',
                             help="Calibrations to take in the form ")
-        parser.add_argument("-t", "--time", "--estimate", dest="estimate",
+        parser.add_argument("-v", "-t", "--time", "--estimate", dest="estimate",
                             default=False, action="store_true",
                             help="Estimate the execution time for this OB?")
         parser.add_argument("-s", "--save", dest="save", type=str, default='',

--- a/kpf/utils/BuildCalOB.py
+++ b/kpf/utils/BuildCalOB.py
@@ -13,7 +13,46 @@ from kpf.scripts.RunOB import RunOB
 ##-------------------------------------------------------------------------
 class BuildCalOB(KPFFunction):
     '''From a set of standard prescriptions, build the described calibration OB.
+    Given a list of input strings, parse them in to variations of the standard
+    calibrations and create an OB for them.
 
+    The input string format is `[CalSource],[Object],[nExp],[keywords]`. The
+    first 3 entries are required while the keywords section is optional. Any
+    unspecified values default to match the same CalSource entry in the example
+    OB file in this repo at `kpf/ObservingBlocks/exampleOBs/Calibration.yaml`.
+
+    For example, and input of `EtalonFiber,slewcal,5` will generate an OB which
+    takes 5 etalon frames with the object name of "slewcal". No keywords are
+    provided, so all other elements of the OB are the default values (e.g. the
+    exposure time and ND filters).
+
+    The keywords can be used to modify those default values in the OB. For
+    example, if the input is:
+    `[CalSource],[Object],[nExp],[keywords],IntensityMonitor=True`
+    then the resulting OB will have the `IntensityMonitor` value set to True
+    rather than the default of False and
+    `[CalSource],[Object],[nExp],[keywords],ExpTime=30`
+    will result in an OB with 30 second exposure times instead of the default
+    of 40 seconds.
+
+    Multiple inputs can be given to create multi-calibration OBs, either as a
+    list in python or on the command line. For example:
+    `kpfdo BuildCalOB Dark,autocal-dark,1,ExpTime=1200 EtalonFiber,autocal-etalon-all-midday,3,IntensityMonitor=True BrdbandFiber,autocal-flat-all,95,IntensityMonitor=True`
+    will generate an OB with three calibrations: a 1200 second dark, 3 Etalon
+    frames, and 95 flat field frames.
+
+    Args:
+        calinputs (list of strings): Input strings as described above.
+        estimate (bool): Generate the OB, run the `EstimateOBDuration` tool,
+                         and print the results to screen.
+        save (string): Save resulting OB to the specified file.
+        overwrite (bool): Overwrite output file if it exists?
+        execute (bool): Execute the resulting OB?
+
+    Functions Called:
+
+    - `EstimateOBDuration`
+    - `RunOB`
     '''
     @classmethod
     def pre_condition(cls, args):

--- a/kpf/utils/BuildCalOB.py
+++ b/kpf/utils/BuildCalOB.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+import copy
+
+from kpf.exceptions import *
+from kpf.KPFTranslatorFunction import KPFFunction, KPFScript
+from kpf.ObservingBlocks.ObservingBlock import ObservingBlock
+
+
+##-------------------------------------------------------------------------
+## BuildCalOB
+##-------------------------------------------------------------------------
+class BuildCalOB(KPFFunction):
+    '''From a set of standard prescriptions, build the described calibration OB.
+
+    '''
+    @classmethod
+    def pre_condition(cls, args):
+        pass
+
+    @classmethod
+    def perform(cls, args):
+        # Build dict of example calibrations
+        example_cal_file = Path(__file__).parent.parent / 'ObservingBlocks' / 'exampleOBs' / 'Calibrations.yaml'
+        if example_cal_file.exists() != True:
+            print(f'Failed to open {example_cal_file:s}')
+            return
+        example_OB = ObservingBlock(example_cal_file)
+        example_cals = {}
+        for cal in example_OB.Calibrations:
+            if cal.CalSource not in example_cals.keys():
+                example_cals[str(cal.CalSource)] = cal
+
+        # Build fresh OB
+        OB = ObservingBlock({})
+        for calinput in args.get('calinputs'):
+            calspec = calinput.split(',')
+            # [CalSource],[Object],[nExp],**kwargs
+            example = example_cals.get(calspec[0], None)
+            if example is None:
+                print(f'Unable to find example calibrations for {calspec[0]}')
+            else:
+                cal = copy.deepcopy(example)
+                cal.set('Object', calspec[1])
+                cal.set('nExp', int(calspec[2]))
+                if len(calspec) > 3:
+                    kwargs = calspec[3:]
+                    for kwarg in kwargs:
+                        key,value = kwarg.split('=')
+                        if key in ['Exptime']:
+                            cal.set(key, float(value))
+                        elif key in ['TriggerCaHK', 'TriggerGreen', 'TriggerRed',
+                                     'IntensityMonitor', 'OpenScienceShutter',
+                                     'OpenSkyShutter', 'TakeSimulCal']:
+                            cal.set(key, bool(value))
+                        else:
+                            cal.set(key, value)
+                OB.Calibrations.append(cal)
+        print(OB.__repr__())
+
+
+    @classmethod
+    def post_condition(cls, argsKPFFunction):
+        pass
+
+    @classmethod
+    def add_cmdline_args(cls, parser):
+        parser.add_argument('calinputs', nargs='*',
+                            help="Calibrations to take in the form ")
+        return super().add_cmdline_args(parser)

--- a/kpf/utils/BuildCalOB.py
+++ b/kpf/utils/BuildCalOB.py
@@ -57,11 +57,12 @@ class BuildCalOB(KPFFunction):
                             cal.set(key, value)
                 OB.Calibrations.append(cal)
 
-        if args.get('estimate', False):
-            EstimateOBDuration.execute({}, OB=OB)
-
         if args.get('save', '') != '':
             OB.write_to(args.get('save'), overwrite=args.get('overwrite', False))
+
+        if args.get('estimate', False):
+            duration = EstimateOBDuration.execute({}, OB=OB)
+            return duration
 
     @classmethod
     def post_condition(cls, argsKPFFunction):

--- a/kpf/utils/EndOfNight.py
+++ b/kpf/utils/EndOfNight.py
@@ -144,13 +144,13 @@ class EndOfNight(KPFFunction):
                     ControlAOHatch.execute({'destination': 'closed'})
                 except FailedToReachDestination:
                     log.error(f"AO hatch did not move successfully")
-                except Exceptions as e:
+                except Exception as e:
                     log.error(f"Failure controlling AO hatch")
                     log.error(e)
                 log.info('Sending PCU stage to Home position')
                 try:
                     SendPCUtoHome.execute({})
-                except Exceptions as e:
+                except Exception as e:
                     log.error(f"Failure sending PCU to home")
                     log.error(e)
     #             log.info('Turning on AO HEPA Filter System')

--- a/kpf/utils/EndOfNight.py
+++ b/kpf/utils/EndOfNight.py
@@ -126,8 +126,10 @@ class EndOfNight(KPFFunction):
         if args.get('AO', True) is True and args.get('confirm', False) is False:
             msg = ["",
                    "--------------------------------------------------------------",
-                   "Perform shutdown of AO? This will move the AO hatch and PCU.",
-                   "The AO area should be clear of personnel before proceeding.",
+                   "Perform shutdown of AO? This will:",
+                   "  - Close the AO hatch",
+                   "  - Send the PCU to home",
+                   "These steps should not be run if OSIRIS is in use.",
                    "",
                    "Do you wish to shutdown AO?",
                    "(y/n) [y]:",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -255,6 +255,7 @@ nav:
       - "kpf.telescope":
         - "EastNorth": scripts/EastNorth.md
       - "kpf.utils":
+        - "BuildCalOB": scripts/BuildCalOB.md
         - "CheckAllowScheduledCals": scripts/CheckAllowScheduledCals.md
         - "EndOfNight": scripts/EndOfNight.md
         - "SetObserverFromSchedule": scripts/SetObserverFromSchedule.md


### PR DESCRIPTION
Changes for v2.0.3

- Add function to build a calibration OB on the fly (`BuildCalOB`)
- Updates to standard cals and to etalon reference file (post SM4)
- Don't send PCU home at end of night (speeds up transitions)
- Add option to OB GUI to load a KPF-CC schedule on non-KPF-CC nights
- numerous bug fixes and small improvements